### PR TITLE
Make Kotlin compileOnly dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,8 @@ apply plugin: 'maven-publish'
 apply plugin: 'com.jfrog.bintray'
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    compileOnly "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    testCompile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     testCompile name: 'idea_rt'
     testCompile 'junit:junit:4.12'
 


### PR DESCRIPTION
Hi!

`build.gradle`  specifies `compile` dependency on `kotlin-runtime` and `kotlin-stdlib`, version 1.0.3. It is propagated to `runtime` dependency as well, so any plugin which uses `intellij-markdown`, will then bundle `kotlin-runtime` and `kotlin-stdlib` jars. This happens for Intellij-rust. I believe it also affects https://github.com/JetBrains/intellij-plugins/tree/master/markdown though I have not checked that specifically. 

And intellij-plugins should not bundle their own Kotlin jars: http://www.jetbrains.org/intellij/sdk/docs/tutorials/kotlin.html#kotlin-gradle-plugin

I believe this PR should fix the issue. An alternative would be to somehow exclude this jar in the plugins themselves.  