### PR TITLE
Add JvmField annotations for token and element types declarations

### DIFF
--- a/src/commonMain/kotlin/org/intellij/markdown/MarkdownElementTypes.kt
+++ b/src/commonMain/kotlin/org/intellij/markdown/MarkdownElementTypes.kt
@@ -1,49 +1,70 @@
 package org.intellij.markdown
 
+import kotlin.jvm.JvmField
+
 object MarkdownElementTypes {
+    @JvmField
     val MARKDOWN_FILE: IElementType = MarkdownElementType("MARKDOWN_FILE")
-
+    @JvmField
     val UNORDERED_LIST: IElementType = MarkdownElementType("UNORDERED_LIST")
-
+    @JvmField
     val ORDERED_LIST: IElementType = MarkdownElementType("ORDERED_LIST")
-
+    @JvmField
     val LIST_ITEM: IElementType = MarkdownElementType("LIST_ITEM")
-
+    @JvmField
     val BLOCK_QUOTE: IElementType = MarkdownElementType("BLOCK_QUOTE")
-
+    @JvmField
     val CODE_FENCE: IElementType = MarkdownElementType("CODE_FENCE")
-
+    @JvmField
     val CODE_BLOCK: IElementType = MarkdownElementType("CODE_BLOCK")
-
+    @JvmField
     val CODE_SPAN: IElementType = MarkdownElementType("CODE_SPAN")
-
+    @JvmField
     val HTML_BLOCK: IElementType = MarkdownElementType("HTML_BLOCK")
-
+    @JvmField
     val PARAGRAPH: IElementType = MarkdownElementType("PARAGRAPH", true)
-
+    @JvmField
     val EMPH: IElementType = MarkdownElementType("EMPH")
-
+    @JvmField
     val STRONG: IElementType = MarkdownElementType("STRONG")
 
+    @JvmField
     val LINK_DEFINITION: IElementType = MarkdownElementType("LINK_DEFINITION")
+    @JvmField
     val LINK_LABEL: IElementType = MarkdownElementType("LINK_LABEL", true)
+    @JvmField
     val LINK_DESTINATION: IElementType = MarkdownElementType("LINK_DESTINATION", true)
+    @JvmField
     val LINK_TITLE: IElementType = MarkdownElementType("LINK_TITLE", true)
+    @JvmField
     val LINK_TEXT: IElementType = MarkdownElementType("LINK_TEXT", true)
+    @JvmField
     val INLINE_LINK: IElementType = MarkdownElementType("INLINE_LINK")
+    @JvmField
     val FULL_REFERENCE_LINK: IElementType = MarkdownElementType("FULL_REFERENCE_LINK")
+    @JvmField
     val SHORT_REFERENCE_LINK: IElementType = MarkdownElementType("SHORT_REFERENCE_LINK")
+    @JvmField
     val IMAGE: IElementType = MarkdownElementType("IMAGE")
 
+    @JvmField
     val AUTOLINK: IElementType = MarkdownElementType("AUTOLINK")
 
+    @JvmField
     val SETEXT_1: IElementType = MarkdownElementType("SETEXT_1")
+    @JvmField
     val SETEXT_2: IElementType = MarkdownElementType("SETEXT_2")
 
+    @JvmField
     val ATX_1: IElementType = MarkdownElementType("ATX_1")
+    @JvmField
     val ATX_2: IElementType = MarkdownElementType("ATX_2")
+    @JvmField
     val ATX_3: IElementType = MarkdownElementType("ATX_3")
+    @JvmField
     val ATX_4: IElementType = MarkdownElementType("ATX_4")
+    @JvmField
     val ATX_5: IElementType = MarkdownElementType("ATX_5")
+    @JvmField
     val ATX_6: IElementType = MarkdownElementType("ATX_6")
 }

--- a/src/commonMain/kotlin/org/intellij/markdown/MarkdownTokenTypes.kt
+++ b/src/commonMain/kotlin/org/intellij/markdown/MarkdownTokenTypes.kt
@@ -1,88 +1,128 @@
 package org.intellij.markdown
 
+import kotlin.jvm.JvmField
+
 open class MarkdownTokenTypes {
     companion object {
+        @JvmField
         val TEXT: IElementType = MarkdownElementType("TEXT", true)
 
+        @JvmField
         val CODE_LINE: IElementType = MarkdownElementType("CODE_LINE", true)
 
+        @JvmField
         val BLOCK_QUOTE: IElementType = MarkdownElementType("BLOCK_QUOTE", true)
 
+        @JvmField
         val HTML_BLOCK_CONTENT: IElementType = MarkdownElementType("HTML_BLOCK_CONTENT", true)
 
+        @JvmField
         val SINGLE_QUOTE: IElementType = MarkdownElementType("'", true)
 
+        @JvmField
         val DOUBLE_QUOTE: IElementType = MarkdownElementType("\"", true)
 
+        @JvmField
         val LPAREN: IElementType = MarkdownElementType("(", true)
 
+        @JvmField
         val RPAREN: IElementType = MarkdownElementType(")", true)
 
+        @JvmField
         val LBRACKET: IElementType = MarkdownElementType("[", true)
 
+        @JvmField
         val RBRACKET: IElementType = MarkdownElementType("]", true)
 
+        @JvmField
         val LT: IElementType = MarkdownElementType("<", true)
 
+        @JvmField
         val GT: IElementType = MarkdownElementType(">", true)
 
+        @JvmField
         val COLON: IElementType = MarkdownElementType(":", true)
 
+        @JvmField
         val EXCLAMATION_MARK: IElementType = MarkdownElementType("!", true)
 
+        @JvmField
         val HARD_LINE_BREAK: IElementType = MarkdownElementType("BR", true)
 
+        @JvmField
         val EOL: IElementType = MarkdownElementType("EOL", true)
 
+        @JvmField
         val LINK_ID: IElementType = MarkdownElementType("LINK_ID", true)
 
+        @JvmField
         val ATX_HEADER: IElementType = MarkdownElementType("ATX_HEADER", true)
 
+        @JvmField
         val ATX_CONTENT: IElementType = MarkdownElementType("ATX_CONTENT", true)
 
+        @JvmField
         val SETEXT_1: IElementType = MarkdownElementType("SETEXT_1", true)
 
+        @JvmField
         val SETEXT_2: IElementType = MarkdownElementType("SETEXT_2", true)
 
+        @JvmField
         val SETEXT_CONTENT: IElementType = MarkdownElementType("SETEXT_CONTENT", true)
 
+        @JvmField
         val EMPH: IElementType = MarkdownElementType("EMPH", true)
 
+        @JvmField
         val BACKTICK: IElementType = MarkdownElementType("BACKTICK", true)
 
+        @JvmField
         val ESCAPED_BACKTICKS: IElementType = MarkdownElementType("ESCAPED_BACKTICKS", true)
 
+        @JvmField
         val LIST_BULLET: IElementType = MarkdownElementType("LIST_BULLET", true)
 
+        @JvmField
         val URL: IElementType = MarkdownElementType("URL", true)
 
+        @JvmField
         val HORIZONTAL_RULE: IElementType = MarkdownElementType("HORIZONTAL_RULE", true)
 
+        @JvmField
         val LIST_NUMBER: IElementType = MarkdownElementType("LIST_NUMBER", true)
 
+        @JvmField
         val FENCE_LANG: IElementType = MarkdownElementType("FENCE_LANG", true)
 
+        @JvmField
         val CODE_FENCE_START: IElementType = MarkdownElementType("CODE_FENCE_START", true)
 
+        @JvmField
         val CODE_FENCE_CONTENT: IElementType = MarkdownElementType("CODE_FENCE_CONTENT", true)
 
+        @JvmField
         val CODE_FENCE_END: IElementType = MarkdownElementType("CODE_FENCE_END", true)
 
+        @JvmField
         val LINK_TITLE: IElementType = MarkdownElementType("LINK_TITLE", true)
 
+        @JvmField
         val AUTOLINK: IElementType = MarkdownElementType("AUTOLINK", true)
 
+        @JvmField
         val EMAIL_AUTOLINK: IElementType = MarkdownElementType("EMAIL_AUTOLINK", true)
 
+        @JvmField
         val HTML_TAG: IElementType = MarkdownElementType("HTML_TAG", true)
 
+        @JvmField
         val BAD_CHARACTER: IElementType = MarkdownElementType("BAD_CHARACTER", true)
 
+        @JvmField
         val WHITE_SPACE: IElementType = object : MarkdownElementType("WHITE_SPACE", true) {
             override fun toString(): String {
                 return "WHITE_SPACE"
             }
         }
-
     }
 }

--- a/src/commonMain/kotlin/org/intellij/markdown/flavours/gfm/GFMElementTypes.kt
+++ b/src/commonMain/kotlin/org/intellij/markdown/flavours/gfm/GFMElementTypes.kt
@@ -2,26 +2,35 @@ package org.intellij.markdown.flavours.gfm
 
 import org.intellij.markdown.IElementType
 import org.intellij.markdown.MarkdownElementType
+import kotlin.jvm.JvmField
 
 object GFMTokenTypes {
-
+    @JvmField
     val TILDE: IElementType = MarkdownElementType("~", true)
 
+    @JvmField
     val TABLE_SEPARATOR: IElementType = MarkdownElementType("TABLE_SEPARATOR", true)
 
+    @JvmField
     val GFM_AUTOLINK: IElementType = MarkdownElementType("GFM_AUTOLINK", true)
 
+    @JvmField
     val CHECK_BOX: IElementType = MarkdownElementType("CHECK_BOX", true)
 
+    @JvmField
     val CELL: IElementType = MarkdownElementType("CELL", true)
 }
 
 object  GFMElementTypes {
+    @JvmField
     val STRIKETHROUGH: IElementType = MarkdownElementType("STRIKETHROUGH")
 
+    @JvmField
     val TABLE: IElementType = MarkdownElementType("TABLE")
 
+    @JvmField
     val HEADER: IElementType = MarkdownElementType("HEADER")
 
+    @JvmField
     val ROW: IElementType = MarkdownElementType("ROW")
 }


### PR DESCRIPTION
Add `@JvmField` annotations to tokens and element types declarations so they can be used by their actual names without `.INSTANCE` field and `get` prefix.