### PR TITLE
Enable JS IR compilation support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,10 +46,8 @@ kotlin {
             }
         }
     }
-    js(LEGACY) {
-        nodejs {
-            binaries.executable()
-        }
+    js(BOTH) {
+        nodejs {}
     }
     linuxX64()
     mingwX64()
@@ -82,7 +80,6 @@ kotlin {
         val jsTest by getting {
             dependencies {
                 implementation(kotlin("test-js"))
-                implementation("org.jetbrains.kotlinx:kotlinx-nodejs:0.0.7")
             }
         }
         val nativeMain by creating {


### PR DESCRIPTION
Commit 47d352a7 previously disabled IR compilation due to tests not
functioning. In order to use `js(BOTH)`, I removed the unused dependency
on kotlinx-nodejs (that library is just headers based on TypeScript
definitions, it isn't necessary for running on node), and the
unnecessary `binaries.executable()` (it's not necessary for tests, and
there are no other js binaries in this repo).