### PR TITLE
Fix using markdown from background thread on Kotlin/Native targets

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: eskatos/gradle-command-action@v1
         with:
           dependencies-cache-enabled: true
-          arguments: macosX64Test iosX64Test --stacktrace
+          arguments: macosX64Test macosX64BackgroundTest iosX64Test iosX64BackgroundTest --stacktrace
       - name: Bundle the build report
         if: failure()
         run: find . -type d -name 'reports' | zip -@ -r build-reports.zip

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,9 @@ import java.io.ByteArrayOutputStream
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.jetbrains.configureBintrayPublicationIfNecessary
 import org.jetbrains.configureSonatypePublicationIfNecessary
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTargetWithTests
+import org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType
+import org.jetbrains.kotlin.gradle.plugin.mpp.TestExecutable
 import org.jetbrains.registerPublicationFromKotlinPlugin
 import org.jetbrains.signPublicationsIfNecessary
 
@@ -121,8 +124,21 @@ kotlin {
         val iosTest by getting {
         }
     }
-}
 
+    targets.withType<KotlinNativeTargetWithTests<*>> {
+        binaries {
+            // Configure a separate test where code runs in background
+            test("background", setOf(NativeBuildType.DEBUG)) {
+                freeCompilerArgs += "-trw"
+            }
+        }
+        testRuns {
+            val background by creating {
+                setExecutionSourceFrom(binaries.getByName("backgroundDebugTest") as TestExecutable)
+            }
+        }
+    }
+}
 
 tasks {
     register<Test>("performanceTest") {

--- a/src/commonMain/kotlin/org/intellij/markdown/html/HtmlGenerator.kt
+++ b/src/commonMain/kotlin/org/intellij/markdown/html/HtmlGenerator.kt
@@ -9,8 +9,11 @@ import org.intellij.markdown.ast.visitors.RecursiveVisitor
 import org.intellij.markdown.flavours.MarkdownFlavourDescriptor
 import org.intellij.markdown.html.entities.EntityConverter
 import org.intellij.markdown.parser.LinkMap
+import kotlin.native.concurrent.SharedImmutable
 
 typealias AttributesCustomizer = (node: ASTNode, tagName: CharSequence, attributes: Iterable<CharSequence?>) -> Iterable<CharSequence?>
+
+@SharedImmutable
 val DUMMY_ATTRIBUTES_CUSTOMIZER: AttributesCustomizer = { _, _, attributes -> attributes }
 
 class HtmlGenerator(private val markdownText: String,

--- a/src/commonMain/kotlin/org/intellij/markdown/html/XssSafeLinks.kt
+++ b/src/commonMain/kotlin/org/intellij/markdown/html/XssSafeLinks.kt
@@ -1,8 +1,11 @@
 package org.intellij.markdown.html
 
 import org.intellij.markdown.ast.ASTNode
+import kotlin.native.concurrent.SharedImmutable
 
+@SharedImmutable
 private val UNSAFE_LINK_REGEX = Regex("^(vbscript|javascript|file|data):", RegexOption.IGNORE_CASE)
+@SharedImmutable
 private val ALLOWED_DATA_LINK_REGEX = Regex("^data:image/(gif|png|jpeg|webp);", RegexOption.IGNORE_CASE)
 
 fun makeXssSafeDestination(s: CharSequence): CharSequence {

--- a/src/commonTest/kotlin/org/intellij/markdown/SpecTest.kt
+++ b/src/commonTest/kotlin/org/intellij/markdown/SpecTest.kt
@@ -3,6 +3,7 @@ package org.intellij.markdown
 import org.intellij.markdown.flavours.MarkdownFlavourDescriptor
 import org.intellij.markdown.html.HtmlGenerator
 import org.intellij.markdown.parser.MarkdownParser
+import kotlin.native.concurrent.SharedImmutable
 import kotlin.test.assertEquals
 
 
@@ -17,6 +18,7 @@ abstract class SpecTest(private val flavour: MarkdownFlavourDescriptor) {
     }
 }
 
+@SharedImmutable
 private val HTML_TAG_REGEX = Regex("<[^>]+>")
 
 /** Remove newlines from [html], unless they occur in a tag or within text enclosed by `<pre>` tags. */

--- a/src/fileBasedTest/kotlin/org/intellij/markdown/HtmlGeneratorTestBase.kt
+++ b/src/fileBasedTest/kotlin/org/intellij/markdown/HtmlGeneratorTestBase.kt
@@ -7,7 +7,9 @@ import org.intellij.markdown.html.HtmlGenerator
 import org.intellij.markdown.html.URI
 import org.intellij.markdown.parser.LinkMap
 import org.intellij.markdown.parser.MarkdownParser
+import kotlin.native.concurrent.SharedImmutable
 
+@SharedImmutable
 private val defaultTagRenderer = HtmlGenerator.DefaultTagRenderer(DUMMY_ATTRIBUTES_CUSTOMIZER, false)
 
 abstract class HtmlGeneratorTestBase : TestCase() {

--- a/src/nativeTest/kotlin/org/intellij/markdown/MarkdownTestUtilNative.kt
+++ b/src/nativeTest/kotlin/org/intellij/markdown/MarkdownTestUtilNative.kt
@@ -5,6 +5,7 @@ import kotlinx.cinterop.allocArray
 import kotlinx.cinterop.memScoped
 import kotlinx.cinterop.toKString
 import platform.posix.*
+import kotlin.native.concurrent.SharedImmutable
 import kotlin.test.assertEquals
 
 actual fun readFromFile(path: String): String {
@@ -27,6 +28,7 @@ actual fun assertSameLinesWithFile(path: String, result: String) {
     assertEquals(fileText, result)
 }
 
+@SharedImmutable
 private val intellijMarkdownHome: Lazy<String> = lazy {
     memScoped {
         val buffer = allocArray<ByteVar>(PATH_MAX)


### PR DESCRIPTION
- Marks all top level properties with `@SharedImmutabble` annotation in order to avoid error `kotlin.native.IncorrectDereferenceException: Trying to access top level value not marked as @ThreadLocal or @SharedImmutable from non-main thread
` when calling markdown from background thread.
- Configure additional test tasks for native targets to run code in the background ([the same approach](https://github.com/Kotlin/kotlinx.coroutines/blob/1efc9f16a352632e6b632b4daab075ac882e661a/kotlinx-coroutines-core/build.gradle#L87-L102) was taken by kotlin.coroutines project).