### PR TITLE
Support Kotlin 1.5

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ import org.jetbrains.registerPublicationFromKotlinPlugin
 import org.jetbrains.signPublicationsIfNecessary
 
 plugins {
-    kotlin("multiplatform") version "1.4.10"
+    kotlin("multiplatform") version "1.5.0"
     id("org.jetbrains.dokka") version "1.4.20"
     id("com.jfrog.bintray")
     `maven-publish`

--- a/src/commonMain/kotlin/org/intellij/markdown/html/entities/EntityConverter.kt
+++ b/src/commonMain/kotlin/org/intellij/markdown/html/entities/EntityConverter.kt
@@ -3,7 +3,7 @@ package org.intellij.markdown.html.entities
 import kotlin.text.Regex
 
 object EntityConverter {
-    private const val escapeAllowedString = "\\!\"#\\$%&'\\(\\)\\*\\+,\\-.\\/:;<=>\\?@\\[\\\\\\]\\^_`{\\|}\\~"
+    private const val escapeAllowedString = """!"#\$%&'\(\)\*\+,\-.\/:;<=>\?@\[\\\]\^_`{\|}~"""
     private val replacements: Map<Char, String> = mapOf(
         '"' to "&quot;",
         '&' to "&amp;",
@@ -11,7 +11,7 @@ object EntityConverter {
         '>' to "&gt;"
     )
 
-    private val REGEX = Regex("&(?:([a-zA-Z0-9]+)|#([0-9]{1,8})|#[xX]([a-fA-F0-9]{1,8}));|([\"&<>])")
+    private val REGEX = Regex("""&(?:([a-zA-Z0-9]+)|#([0-9]{1,8})|#[xX]([a-fA-F0-9]{1,8}));|(["&<>])""")
     private val REGEX_ESCAPES = Regex("${REGEX.pattern}|\\\\([${escapeAllowedString}])")
 
     fun replaceEntities(text: CharSequence, processEntities: Boolean, processEscapes: Boolean): String {

--- a/src/commonMain/kotlin/org/intellij/markdown/parser/constraints/CommonMarkdownConstraints.kt
+++ b/src/commonMain/kotlin/org/intellij/markdown/parser/constraints/CommonMarkdownConstraints.kt
@@ -263,7 +263,7 @@ open class CommonMarkdownConstraints protected constructor(private val indents: 
     }
 
     override fun toString(): String {
-        return "MdConstraints: " + String(types) + "(" + indent + ")"
+        return "MdConstraints: " + types.concatToString() + "(" + indent + ")"
     }
 
     companion object {

--- a/src/commonMain/kotlin/org/intellij/markdown/parser/markerblocks/providers/SetextHeaderProvider.kt
+++ b/src/commonMain/kotlin/org/intellij/markdown/parser/markerblocks/providers/SetextHeaderProvider.kt
@@ -44,6 +44,6 @@ class SetextHeaderProvider : MarkerBlockProvider<MarkerProcessor.StateInfo> {
     }
 
     companion object {
-        val REGEX: Regex = Regex("^ {0,3}(\\-+|=+) *$")
+        val REGEX: Regex = Regex("^ {0,3}(-+|=+) *$")
     }
 }


### PR DESCRIPTION
This requires working around KT-46694, which added the `u` flag to all
JS regular expressions. That caused unnecessary escapes in patterns to
throw an error.

Fixes #78