### PR TITLE
Migration to 1.5.10

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ import org.jetbrains.registerPublicationFromKotlinPlugin
 import org.jetbrains.signPublicationsIfNecessary
 
 plugins {
-    kotlin("multiplatform") version "1.4.10"
+    kotlin("multiplatform") version "1.5.10"
     id("org.jetbrains.dokka") version "1.4.20"
     id("com.jfrog.bintray")
     `maven-publish`

--- a/src/commonMain/kotlin/org/intellij/markdown/html/entities/EntityConverter.kt
+++ b/src/commonMain/kotlin/org/intellij/markdown/html/entities/EntityConverter.kt
@@ -3,7 +3,6 @@ package org.intellij.markdown.html.entities
 import kotlin.text.Regex
 
 object EntityConverter {
-    private const val escapeAllowedString = "\\!\"#\\$%&'\\(\\)\\*\\+,\\-.\\/:;<=>\\?@\\[\\\\\\]\\^_`{\\|}\\~"
     private val replacements: Map<Char, String> = mapOf(
         '"' to "&quot;",
         '&' to "&amp;",
@@ -50,3 +49,5 @@ object EntityConverter {
         }
     }
 }
+
+expect val escapeAllowedString: String

--- a/src/commonMain/kotlin/org/intellij/markdown/parser/constraints/CommonMarkdownConstraints.kt
+++ b/src/commonMain/kotlin/org/intellij/markdown/parser/constraints/CommonMarkdownConstraints.kt
@@ -263,7 +263,7 @@ open class CommonMarkdownConstraints protected constructor(private val indents: 
     }
 
     override fun toString(): String {
-        return "MdConstraints: " + String(types) + "(" + indent + ")"
+        return "MdConstraints: " + types.concatToString() + "(" + indent + ")"
     }
 
     companion object {

--- a/src/commonMain/kotlin/org/intellij/markdown/parser/markerblocks/providers/SetextHeaderProvider.kt
+++ b/src/commonMain/kotlin/org/intellij/markdown/parser/markerblocks/providers/SetextHeaderProvider.kt
@@ -44,6 +44,6 @@ class SetextHeaderProvider : MarkerBlockProvider<MarkerProcessor.StateInfo> {
     }
 
     companion object {
-        val REGEX: Regex = Regex("^ {0,3}(\\-+|=+) *$")
+        val REGEX: Regex = Regex("^ {0,3}(-+|=+) *$")
     }
 }

--- a/src/jsMain/kotlin/org/intellij/markdown/html/entities/escapeAllowedString.kt
+++ b/src/jsMain/kotlin/org/intellij/markdown/html/entities/escapeAllowedString.kt
@@ -1,0 +1,3 @@
+package org.intellij.markdown.html.entities
+
+actual val escapeAllowedString: String = "\\\\!\"#\\$%&'\\\\(\\\\)\\\\*\\\\+,\\-.\\\\/:;<=>\\\\?@\\\\[\\\\\\]\\\\^_`{''\\\\|}\\\\~"

--- a/src/jvmMain/kotlin/org/intellij/markdown/html/entities/escapeAllowedString.kt
+++ b/src/jvmMain/kotlin/org/intellij/markdown/html/entities/escapeAllowedString.kt
@@ -1,0 +1,3 @@
+package org.intellij.markdown.html.entities
+
+actual val escapeAllowedString: String = "\\!\"#\\$%&'\\(\\)\\*\\+,\\-.\\/:;<=>\\?@\\[\\\\\\]\\^_`{\\|}\\~"

--- a/src/nativeMain/kotlin/org/intellij/markdown/html/entities/escapeAllowedString.kt
+++ b/src/nativeMain/kotlin/org/intellij/markdown/html/entities/escapeAllowedString.kt
@@ -1,0 +1,3 @@
+package org.intellij.markdown.html.entities
+
+actual val escapeAllowedString: String = "\\!\"#\\$%&'\\(\\)\\*\\+,\\-.\\/:;<=>\\?@\\[\\\\\\]\\^_`{\\|}\\~"


### PR DESCRIPTION
Since 1.5.10 Kotlin/JS regexps [was changed](https://youtrack.jetbrains.com/issue/KT-45928), Unicode flag was enabled, and requirements to regexp was changed