### PR TITLE
ArrayList.pop() in GeneratedLexer.kt does not remove element

### DIFF
--- a/src/commonMain/kotlin/org/intellij/markdown/lexer/GeneratedLexer.kt
+++ b/src/commonMain/kotlin/org/intellij/markdown/lexer/GeneratedLexer.kt
@@ -19,8 +19,4 @@ fun <E> ArrayList<E>.push(e: E) {
     add(e)
 }
 
-fun <E> ArrayList<E>.pop(): E {
-    val result = last()
-    dropLast(1)
-    return result;
-}
+fun <E> ArrayList<E>.pop(): E = removeLast()


### PR DESCRIPTION
`dropLast(1)` just returns a list without the last element, it does not modify the list.
This seems unintended.