### PR TITLE
#114 Allow using HTTPS schema in GFM auto links without schema

### DIFF
--- a/src/fileBasedTest/kotlin/org/intellij/markdown/HtmlGeneratorCommonTest.kt
+++ b/src/fileBasedTest/kotlin/org/intellij/markdown/HtmlGeneratorCommonTest.kt
@@ -118,6 +118,11 @@ class HtmlGeneratorCommonTest : HtmlGeneratorTestBase() {
     }
 
     @Test
+    fun testGfmAutolinkWithHttps() {
+        defaultTest(GFMFlavourDescriptor(makeHttpsAutoLinks = true))
+    }
+
+    @Test
     fun testSfmAutolink() {
         defaultTest(SFMFlavourDescriptor(false))
     }

--- a/src/fileBasedTest/resources/data/html/gfmAutolinkWithHttps.md
+++ b/src/fileBasedTest/resources/data/html/gfmAutolinkWithHttps.md
@@ -1,0 +1,1 @@
+www.aaa.bbb

--- a/src/fileBasedTest/resources/data/html/gfmAutolinkWithHttps.txt
+++ b/src/fileBasedTest/resources/data/html/gfmAutolinkWithHttps.txt
@@ -1,0 +1,5 @@
+<body>
+<p>
+<a href="https://www.aaa.bbb">www.aaa.bbb</a>
+</p>
+</body>


### PR DESCRIPTION
By default `GFMFlavourDescriptor` uses HTTP schema in HTML generator which is insecure.
This change allows override this behaviour by providing `makeHttpsAutoLinks = true` parameter.

Fixes #114 