### PR TITLE
[#135] Create nodes for cells with zero lengths

### DIFF
--- a/src/commonMain/kotlin/org/intellij/markdown/parser/TreeBuilder.kt
+++ b/src/commonMain/kotlin/org/intellij/markdown/parser/TreeBuilder.kt
@@ -91,7 +91,7 @@ abstract class TreeBuilder(protected val nodeBuilder: ASTNodeBuilder) {
             if (isStart() == other.isStart()) {
                 val positionDiff = info.range.first + info.range.last - (other.info.range.first + other.info.range.last)
                 if (positionDiff != 0) {
-                    if (isEmpty()) {
+                    if (isEmpty() || other.isEmpty()) {
                         return positionDiff
                     }
                     return -positionDiff

--- a/src/commonMain/kotlin/org/intellij/markdown/parser/TreeBuilder.kt
+++ b/src/commonMain/kotlin/org/intellij/markdown/parser/TreeBuilder.kt
@@ -91,6 +91,9 @@ abstract class TreeBuilder(protected val nodeBuilder: ASTNodeBuilder) {
             if (isStart() == other.isStart()) {
                 val positionDiff = info.range.first + info.range.last - (other.info.range.first + other.info.range.last)
                 if (positionDiff != 0) {
+                    if (isEmpty()) {
+                        return positionDiff
+                    }
                     return -positionDiff
                 }
 

--- a/src/commonMain/kotlin/org/intellij/markdown/parser/markerblocks/impl/AtxHeaderMarkerBlock.kt
+++ b/src/commonMain/kotlin/org/intellij/markdown/parser/markerblocks/impl/AtxHeaderMarkerBlock.kt
@@ -20,13 +20,28 @@ class AtxHeaderMarkerBlock(myConstraints: MarkdownConstraints,
 
     init {
         val curPos = productionHolder.currentPosition
-        productionHolder.addProduction(listOf(SequentialParser.Node(
-                curPos + headerRange.first..curPos + headerRange.last + 1, MarkdownTokenTypes.ATX_HEADER
-        ), SequentialParser.Node(
-                curPos + headerRange.last + 1..tailStartPos, MarkdownTokenTypes.ATX_CONTENT
-        ), SequentialParser.Node(
-                tailStartPos..endOfLinePos, MarkdownTokenTypes.ATX_HEADER
-        )))
+        val nodes = buildList {
+            add(
+                SequentialParser.Node(
+                    curPos + headerRange.first..curPos + headerRange.last + 1, MarkdownTokenTypes.ATX_HEADER
+                )
+            )
+            if (curPos + headerRange.last + 1 != tailStartPos) {
+                add(
+                    SequentialParser.Node(
+                        curPos + headerRange.last + 1..tailStartPos, MarkdownTokenTypes.ATX_CONTENT
+                    )
+                )
+            }
+            if (tailStartPos != endOfLinePos) {
+                add(
+                    SequentialParser.Node(
+                        tailStartPos..endOfLinePos, MarkdownTokenTypes.ATX_HEADER
+                    )
+                )
+            }
+        }
+        productionHolder.addProduction(nodes)
     }
 
     override fun isInterestingOffset(pos: LookaheadText.Position): Boolean = true

--- a/src/fileBasedTest/resources/data/parser/gfmTable.txt
+++ b/src/fileBasedTest/resources/data/parser/gfmTable.txt
@@ -245,9 +245,13 @@ Markdown:MARKDOWN_FILE
   Markdown:TABLE
     Markdown:HEADER
       Markdown:TABLE_SEPARATOR('|')
+      Markdown:CELL
       Markdown:TABLE_SEPARATOR('|')
+      Markdown:CELL
       Markdown:TABLE_SEPARATOR('|')
+      Markdown:CELL
       Markdown:TABLE_SEPARATOR('|')
+      Markdown:CELL
       Markdown:TABLE_SEPARATOR('|')
     Markdown:EOL('\n')
     Markdown:TABLE_SEPARATOR('---|---|---|---')


### PR DESCRIPTION
Here `GitHubTableMarkerBlock#fillCells` nodes for cells and separators are created. And a node for a cell is created even if its length is zero.
And then here `TreeBuilder#constructEvents` events are created, and for nodes with zero lengths, only one event is created (and not two as elsewhere). And then after sorting, these events are strangely located. Such a cell appears to be between the opening and closing of the separator.
Therefore, I think that it is necessary to correct how these events are compared, specifically in the case of an empty event.