### PR TITLE
Add linuxArm64 target

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,6 +57,7 @@ kotlin {
         nodejs()
     }
     linuxX64()
+    linuxArm64()
     mingwX64()
     macosX64()
     macosArm64()
@@ -94,6 +95,7 @@ kotlin {
         }
         val nativeSourceSets = listOf(
             "linuxX64",
+            "linuxArm64",
             "mingwX64",
             "macosX64",
             "macosArm64",
@@ -109,6 +111,7 @@ kotlin {
         }
         val nativeTestSourceSets = listOf(
             "linuxX64",
+            "linuxArm64",
             "mingwX64",
             "macosX64",
             "macosArm64"
@@ -215,6 +218,7 @@ val publicationsToArtifacts = mapOf(
     "jvm" to "markdown-jvm",
     "js" to "markdown-js",
     "linuxX64" to "markdown-linuxx64",
+    "linuxArm64" to "markdown-linuxarm64",
     "mingwX64" to "markdown-mingwx64",
     "macosX64" to "markdown-macosx64",
     "macosArm64" to "markdown-macosarm64",

--- a/src/linuxArm64Test/kotlin/org/intellij/markdown/CurrentDirectory.kt
+++ b/src/linuxArm64Test/kotlin/org/intellij/markdown/CurrentDirectory.kt
@@ -1,0 +1,8 @@
+package org.intellij.markdown
+
+import kotlinx.cinterop.*
+
+@OptIn(ExperimentalForeignApi::class)
+actual fun getcwd(buffer: CValuesRef<ByteVar>, maxPath: Int): CPointer<ByteVar>? {
+  return platform.posix.getcwd(buffer, maxPath.convert())
+}


### PR DESCRIPTION
This PR adds the `linuxArm64` target. It's compiled on CI, but not tested to run, which is in line with its [Tier 2 support][1]

Fixes #146

[1]: https://kotlinlang.org/docs/native-target-support.html#tier-2