### PR TITLE
Fixing Gfm code span rendering in terms of "\" and spaces.

### DIFF
--- a/src/commonTest/kotlin/org/intellij/markdown/GfmSpecTest.kt
+++ b/src/commonTest/kotlin/org/intellij/markdown/GfmSpecTest.kt
@@ -2089,14 +2089,12 @@ class GfmSpecTest : SpecTest(org.intellij.markdown.flavours.gfm.GFMFlavourDescri
     )
 
     @Test
-    @Ignore
     fun testCodeSpansExample341() = doTest(
             markdown = "`  ``  `\n",
             html = "<p><code> `` </code></p>\n"
     )
 
     @Test
-    @Ignore
     fun testCodeSpansExample342() = doTest(
             markdown = "` a`\n",
             html = "<p><code> a</code></p>\n"
@@ -2110,35 +2108,30 @@ class GfmSpecTest : SpecTest(org.intellij.markdown.flavours.gfm.GFMFlavourDescri
     )
 
     @Test
-    @Ignore
     fun testCodeSpansExample344() = doTest(
             markdown = "` `\n`  `\n",
             html = "<p><code> </code>\n<code>  </code></p>\n"
     )
 
     @Test
-    @Ignore
     fun testCodeSpansExample345() = doTest(
             markdown = "``\nfoo\nbar  \nbaz\n``\n",
             html = "<p><code>foo bar   baz</code></p>\n"
     )
 
     @Test
-    @Ignore
     fun testCodeSpansExample346() = doTest(
             markdown = "``\nfoo \n``\n",
             html = "<p><code>foo </code></p>\n"
     )
 
     @Test
-    @Ignore
     fun testCodeSpansExample347() = doTest(
             markdown = "`foo   bar \nbaz`\n",
             html = "<p><code>foo   bar  baz</code></p>\n"
     )
 
     @Test
-    @Ignore
     fun testCodeSpansExample348() = doTest(
             markdown = "`foo\\`bar`\n",
             html = "<p><code>foo\\</code>bar`</p>\n"

--- a/src/fileBasedTest/resources/data/html/ruby17351.txt
+++ b/src/fileBasedTest/resources/data/html/ruby17351.txt
@@ -318,15 +318,15 @@ Enter key password for [tomcat]<br />
 <code>&lt;Connector port=&quot;8443&quot; protocol=&quot;org.apache.coyote.http11.Http11Protocol&quot;</code>
 <br />
 
-    <code>maxThreads=&quot;150&quot; SSLEnabled=&quot;true&quot; scheme=&quot;https&quot; secure=&quot;true&quot;</code>
+    <code>    maxThreads=&quot;150&quot; SSLEnabled=&quot;true&quot; scheme=&quot;https&quot; secure=&quot;true&quot;</code>
 <br />
 
-    <code>clientAuth=&quot;false&quot; sslProtocol=&quot;TLS&quot;</code>
+    <code>    clientAuth=&quot;false&quot; sslProtocol=&quot;TLS&quot;</code>
 <br />
 
-    <code>keystoreFile=&quot;/opt/certs/tomcatSSLKeystore&quot;</code>
+    <code>    keystoreFile=&quot;/opt/certs/tomcatSSLKeystore&quot;</code>
 
-    <code>keystorePass=&quot;changeit&quot; /&gt;</code>
+    <code>    keystorePass=&quot;changeit&quot; /&gt;</code>
 </p>
 </li>
 <li>
@@ -843,7 +843,7 @@ Upload Solr configuration to Zookeeper<ol>
 <code>cd /opt/solr-5.3.1/server/scripts/cloud-scripts</code>
 </li>
 <li>
-<code>./zkcli.sh -cmd upconfig -zkhost [zk1-host]:2181,[zk2-host]:2181,[zk3-host]:2181/kla_chroot -confname kla_config -solrhome /opt/solr-5.3.1/server/solr -confdir /opt/solr-5.3.1/server/solr/configsets/data_driven_schema_configs/conf</code>
+<code> ./zkcli.sh -cmd upconfig -zkhost [zk1-host]:2181,[zk2-host]:2181,[zk3-host]:2181/kla_chroot -confname kla_config -solrhome /opt/solr-5.3.1/server/solr -confdir /opt/solr-5.3.1/server/solr/configsets/data_driven_schema_configs/conf</code>
 </li>
 </ol>
 </li>


### PR DESCRIPTION
Re-enabling examples 341, 342, 344, 345, 346, 347, 348 from https://github.github.com/gfm/ in GfmSpecTest.

For code spans, only 353 and 355 are still broken.

Fixes: https://github.com/JetBrains/markdown/issues/149