### PR TITLE
Remove fastutil dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -103,11 +103,6 @@ kotlin {
         val nativeTest by creating {
             dependsOn(fileBasedTest)
         }
-        val jvmMain by getting {
-            dependencies {
-                api("it.unimi.dsi:fastutil-core:8.5.12")
-            }
-        }
         val nativeSourceSets = listOf(
             "linuxX64",
             "linuxArm64",

--- a/src/jvmMain/kotlin/CommonDefsImplJvm.kt
+++ b/src/jvmMain/kotlin/CommonDefsImplJvm.kt
@@ -1,15 +1,13 @@
 package org.intellij.markdown.html
 
-import it.unimi.dsi.fastutil.ints.IntArrayList
-import it.unimi.dsi.fastutil.ints.IntStack
+import org.intellij.markdown.lexer.Stack
 import java.net.URLEncoder
-import java.util.Stack
 
 actual class BitSet actual constructor(size: Int): java.util.BitSet(size){
     actual val size = size()
 }
 
-actual typealias IntStack = IntArrayList
+actual class IntStack: Stack<Int>()
 
 private const val PUNCTUATION_MASK: Int = (1 shl Character.DASH_PUNCTUATION.toInt()) or
         (1 shl Character.START_PUNCTUATION.toInt())     or


### PR DESCRIPTION
As shown in https://github.com/ajalt/clikt/issues/507, the fastutil dependency is over 6MB in size. This dependency is only used in a single line.

This PR removes that dependency and uses the same `Stack<Int>()` on JVM as on the other platforms.

To make sure this doesn't affect performance, I used the following JMH benchmark that converts the `gitBook.md` file from the test data to html:

```kotlin
val parser = MarkdownParser(CommonMarkFlavourDescriptor())
val src = Path.of("../src/fileBasedTest/resources/data/html/gitBook.md").readText()

@Warmup(iterations = 5, time = 1)
@Measurement(iterations = 5, time = 1)
@OutputTimeUnit(TimeUnit.MILLISECONDS)
@BenchmarkMode(Mode.AverageTime)
@Fork(1)
@State(Scope.Benchmark)
open class GitBookBenchmark {
    @Benchmark
    open fun htmlGenerator(): String {
        val parsedTree = parser.buildMarkdownTreeFromString(src)
        return HtmlGenerator(src, parsedTree, CommonMarkFlavourDescriptor()).generateHtml()
    }
}
```

Performance on `master`, with fastutil `IntStack`:

```
Benchmark                       Mode  Cnt   Score   Error  Units
GitBookBenchmark.htmlGenerator  avgt    5  19.293 ± 3.356  ms/op
```

Performance after this PR, with `Stack<Int>()`:

```
Benchmark                       Mode  Cnt   Score   Error  Units
GitBookBenchmark.htmlGenerator  avgt    5  19.288 ± 7.111  ms/op
```

According to this benchmark, the change has no performance impact.