### PR TITLE
Add watchOS and tvOS targets

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Build and run tests with Gradle
         uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
         with:
-          arguments: macosX64Test iosX64Test --stacktrace
+          arguments: macosArm64Test macosX64Test iosSimulatorArm64Test iosX64Test tvosSimulatorArm64Test tvosX64Test watchosSimulatorArm64Test watchosX64Test --stacktrace
 
       - name: Bundle the build report
         if: failure()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -68,10 +68,17 @@ kotlin {
     mingwX64()
     macosX64()
     macosArm64()
+    iosX64()
+    iosArm64()
     iosSimulatorArm64()
+    watchosArm32()
+    watchosArm64()
+    watchosDeviceArm64()
+    watchosX64()
     watchosSimulatorArm64()
+    tvosX64()
+    tvosArm64()
     tvosSimulatorArm64()
-    ios()
 
     sourceSets {
         all {
@@ -114,10 +121,17 @@ kotlin {
             "mingwX64",
             "macosX64",
             "macosArm64",
-            "ios",
+            "iosX64",
+            "iosArm64",
             "iosSimulatorArm64",
+            "watchosArm32",
+            "watchosArm64",
+            "watchosDeviceArm64",
+            "watchosX64",
             "watchosSimulatorArm64",
-            "tvosSimulatorArm64"
+            "tvosX64",
+            "tvosArm64",
+            "tvosSimulatorArm64",
         ).map { "${it}Main" }
         for (set in nativeSourceSets) {
             named(set) {


### PR DESCRIPTION
This library currently only publishes for the simulators for watchOS and tvOS. This PR adds the remaining targets for those platforms.