### PR TITLE
[#124] Fix the java example

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,12 @@ val html = HtmlGenerator(src, parsedTree, flavour).generateHtml()
 ```java
 final String src = "Some *Markdown*";
 final MarkdownFlavourDescriptor flavour = new GFMFlavourDescriptor();
-final ASTNode parsedTree = new MarkdownParser(flavour).buildMarkdownTreeFromString(text);
-final String html = new HtmlGenerator(src, parsedTree, flavour, false).generateHtml();
+final ASTNode parsedTree = new MarkdownParser(flavour).buildMarkdownTreeFromString(src);
+final String html = new HtmlGenerator(src, parsedTree, flavour, false)
+        .generateHtml(new HtmlGenerator.DefaultTagRenderer(
+        (astNode, charSequence, attributes) -> attributes,
+        false)
+        );
 ```
 
 ## Development gotchas


### PR DESCRIPTION
The java example in the document is incorrect, I have modified it to the correct example
Before: 
```java
final String src = "Some *Markdown*";
final MarkdownFlavourDescriptor flavour = new GFMFlavourDescriptor();
final ASTNode parsedTree = new MarkdownParser(flavour).buildMarkdownTreeFromString(text);
final String html = new HtmlGenerator(src, parsedTree, flavour, false).generateHtml();
```


After:
```java
final String src = "Some *Markdown*";
final MarkdownFlavourDescriptor flavour = new GFMFlavourDescriptor();
final ASTNode parsedTree = new MarkdownParser(flavour).buildMarkdownTreeFromString(src);
final String html = new HtmlGenerator(src, parsedTree, flavour, false)
        .generateHtml(new HtmlGenerator.DefaultTagRenderer(
        (astNode, charSequence, attributes) -> attributes,
        false)
        );
```