### PR TITLE
Override `equals` and `hashCode` for IElementType

### DIFF
--- a/src/commonMain/kotlin/org/intellij/markdown/IElementType.kt
+++ b/src/commonMain/kotlin/org/intellij/markdown/IElementType.kt
@@ -1,6 +1,16 @@
 package org.intellij.markdown
 
 open class IElementType(val name: String) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is IElementType) return false
+        return this.name == other.name
+    }
+
+    override fun hashCode(): Int {
+        return name.hashCode()
+    }
+
     override fun toString(): String {
         return name
     }

--- a/src/commonMain/kotlin/org/intellij/markdown/MarkdownElementType.kt
+++ b/src/commonMain/kotlin/org/intellij/markdown/MarkdownElementType.kt
@@ -2,6 +2,19 @@ package org.intellij.markdown
 
 open class MarkdownElementType(name: String, val isToken: Boolean = false) : IElementType(name) {
 
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is MarkdownElementType) return false
+        if (!super.equals(other)) return false
+        return isToken == other.isToken
+    }
+
+    override fun hashCode(): Int {
+        var result = super.hashCode()
+        result = 31 * result + isToken.hashCode()
+        return result
+    }
+
     override fun toString(): String {
         return "Markdown:" + super.toString()
     }


### PR DESCRIPTION
It would be easier to compare objects like the ones in `MarkdownElementTypes`.