### PR TITLE
[gfm] Implement single/double tildes for strikethrough

### DIFF
--- a/src/commonMain/kotlin/org/intellij/markdown/flavours/gfm/GFMFlavourDescriptor.kt
+++ b/src/commonMain/kotlin/org/intellij/markdown/flavours/gfm/GFMFlavourDescriptor.kt
@@ -55,7 +55,7 @@ open class GFMFlavourDescriptor(
     override fun createHtmlGeneratingProviders(linkMap: LinkMap,
                                                baseURI: URI?): Map<IElementType, GeneratingProvider> {
         return super.createHtmlGeneratingProviders(linkMap, baseURI) + hashMapOf(
-                GFMElementTypes.STRIKETHROUGH to object : SimpleInlineTagProvider("span", 2, -2) {
+                GFMElementTypes.STRIKETHROUGH to object : EqualDelimiterTrimmingInlineTagProvider("span", GFMTokenTypes.TILDE) {
                     override fun openTag(visitor: HtmlGenerator.HtmlGeneratingVisitor, text: String, node: ASTNode) {
                         visitor.consumeTagOpen(node, tagName, "class=\"user-del\"")
                     }

--- a/src/commonTest/kotlin/org/intellij/markdown/GfmSpecTest.kt
+++ b/src/commonTest/kotlin/org/intellij/markdown/GfmSpecTest.kt
@@ -3001,16 +3001,34 @@ class GfmSpecTest : SpecTest(org.intellij.markdown.flavours.gfm.GFMFlavourDescri
     //        html = "<p><del>Hi</del> Hello, world!</p>\n"
     //)
 
+    //@Test
+    //fun testStrikethroughExample491() = doTest(
+    //    markdown = "~~Hi~~ Hello, world!\n",
+    //    html = "<p><span class=\"user-del\">Hi</span> Hello, world!</p>\n"
+    //)
+
     @Test
     fun testStrikethroughExample491() = doTest(
-        markdown = "~~Hi~~ Hello, world!\n",
-        html = "<p><span class=\"user-del\">Hi</span> Hello, world!</p>\n"
+        markdown = "~~Hi~~ Hello, ~there~ world!\n",
+        html = "<p><span class=\"user-del\">Hi</span> Hello, <span class=\"user-del\">there</span> world!</p>\n"
     )
 
     @Test
     fun testStrikethroughExample492() = doTest(
-            markdown = "This ~~has a\n\nnew paragraph~~.\n",
-            html = "<p>This ~~has a</p>\n<p>new paragraph~~.</p>\n"
+        markdown = "This ~~has a\n\nnew paragraph~~.\n",
+        html = "<p>This ~~has a</p>\n<p>new paragraph~~.</p>\n"
+    )
+
+    @Test
+    fun testStrikethroughExample493() = doTest(
+        markdown = "This will ~~~not~~~ strike.\n",
+        html = "<p>This will ~~~not~~~ strike.</p>\n"
+    )
+
+    @Test
+    fun testStrikethroughManyWords() = doTest(
+        markdown = "~~Two (so many) words~~\n",
+        html = "<p><span class=\"user-del\">Two (so many) words</span></p>\n"
     )
 
     @Test
@@ -4151,5 +4169,4 @@ class GfmSpecTest : SpecTest(org.intellij.markdown.flavours.gfm.GFMFlavourDescri
             markdown = "Multiple     spaces\n",
             html = "<p>Multiple     spaces</p>\n"
     )
-
 }

--- a/src/fileBasedTest/resources/data/html/ruby17351.md
+++ b/src/fileBasedTest/resources/data/html/ruby17351.md
@@ -379,9 +379,9 @@ Zookeeper is required for SolrCloud to maintain and synchronize the Solr server 
     1. `./zkcli.sh -cmd clear -z localhost:2181/kla_chroot /kla_chroot`
 
 
-#### *~BETA~*
+#### *\~BETA\~*
 ### Jena/Fuseki Local Persistence
-#### *~BETA~*
+#### *\~BETA\~*
 The Knowtify Data Service requires a local data store to be configured so that local data can be stored, managed, and served up to clients. There are 2 possible configurations of the lcoal data store, both of which involve the jena TDB database.
 
 1. Embedded (the database runs in-process to the Data Service). Use this in environments where you are certain there will only ever be a single instance of the Knowtify Data Service to server all of the users.


### PR DESCRIPTION
According to the GFM spec, strikethrough can be indicated with either single or double tildes (~ / ~~).
Currently, the GFMFlavourDescriptor implementation only allows double tildes.

This commit implements single tilde strikethrough and adds/updates tests.

See: https://github.github.com/gfm/#strikethrough-extension-