### PR TITLE
[gfm] Fix the HTML generation for tables inside quotes

### DIFF
--- a/src/commonMain/kotlin/org/intellij/markdown/flavours/gfm/GFMGeneratingProviders.kt
+++ b/src/commonMain/kotlin/org/intellij/markdown/flavours/gfm/GFMGeneratingProviders.kt
@@ -216,7 +216,7 @@ internal class TablesGeneratingProvider : GeneratingProvider {
         val cells = SPLIT_REGEX.split(separatorRow.getTextInNode(text))
         for (i in cells.indices) {
             val cell = cells[i]
-            if (!cell.isBlank() || i in 1..cells.lastIndex - 1) {
+            if (i in 1..cells.lastIndex - 1 || cell.contains('-')) {
                 val trimmed = cell.trim()
                 val starts = trimmed.startsWith(':')
                 val ends = trimmed.endsWith(':')

--- a/src/fileBasedTest/kotlin/org/intellij/markdown/HtmlGeneratorCommonTest.kt
+++ b/src/fileBasedTest/kotlin/org/intellij/markdown/HtmlGeneratorCommonTest.kt
@@ -133,6 +133,11 @@ class HtmlGeneratorCommonTest : HtmlGeneratorTestBase() {
     }
 
     @Test
+    fun testTableInsideBlockQuoteWithMissingLastPipe() {
+        defaultTest(GFMFlavourDescriptor())
+    }
+
+    @Test
     fun testCheckedLists() {
         defaultTest(GFMFlavourDescriptor())
     }

--- a/src/fileBasedTest/resources/data/html/tableInsideBlockQuoteWithMissingLastPipe.md
+++ b/src/fileBasedTest/resources/data/html/tableInsideBlockQuoteWithMissingLastPipe.md
@@ -1,0 +1,5 @@
+> | Table | Frezze | Bug  |
+> | ---   | ------ | ---- |
+> | foo   | some   | fix  |
+> | bar   | item   | plz  
+|

--- a/src/fileBasedTest/resources/data/html/tableInsideBlockQuoteWithMissingLastPipe.txt
+++ b/src/fileBasedTest/resources/data/html/tableInsideBlockQuoteWithMissingLastPipe.txt
@@ -1,0 +1,26 @@
+<body>
+<blockquote>
+<table>
+<thead>
+<tr>
+<th>Table</th>
+<th>Frezze</th>
+<th>Bug</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>foo</td>
+<td>some</td>
+<td>fix</td>
+</tr>
+<tr class="intellij-row-even">
+<td>bar</td>
+<td>item</td>
+<td>plz</td>
+</tr>
+</tbody>
+</table>
+</blockquote>
+<p>|</p>
+</body>


### PR DESCRIPTION
Previously they had an extra column and the alignment was not properly applied