### PR TITLE
Fix parser ignoring everything between reference link text and its label

### DIFF
--- a/src/commonMain/kotlin/org/intellij/markdown/parser/sequentialparsers/impl/ReferenceLinkParser.kt
+++ b/src/commonMain/kotlin/org/intellij/markdown/parser/sequentialparsers/impl/ReferenceLinkParser.kt
@@ -42,8 +42,8 @@ class ReferenceLinkParser : SequentialParser {
                     ?: return null
             var it = linkText.iteratorPosition.advance()
 
-            if (it.type == MarkdownTokenTypes.EOL) {
-                it = it.advance()
+            if (it.start != linkText.iteratorPosition.end) {
+                return null
             }
 
             val linkLabel = LinkParserUtil.parseLinkLabel(it)
@@ -62,23 +62,20 @@ class ReferenceLinkParser : SequentialParser {
 
             val linkLabel = LinkParserUtil.parseLinkLabel(iterator)
                     ?: return null
-            
+
             var it = linkLabel.iteratorPosition
             val shortcutLinkEnd = it
 
             it = it.advance()
-            if (it.type == MarkdownTokenTypes.EOL) {
-                it = it.advance()
-            }
 
-            if (it.type == MarkdownTokenTypes.LBRACKET && it.rawLookup(1) == MarkdownTokenTypes.RBRACKET) {
+            if (it.start == shortcutLinkEnd.end && it.type == MarkdownTokenTypes.LBRACKET && it.rawLookup(1) == MarkdownTokenTypes.RBRACKET) {
                 it = it.advance()
             } else {
                 it = shortcutLinkEnd
             }
 
             return LocalParsingResult(it,
-                    linkLabel.parsedNodes 
+                    linkLabel.parsedNodes
                             + SequentialParser.Node(startIndex..it.index + 1, MarkdownElementTypes.SHORT_REFERENCE_LINK),
                     linkLabel.rangesToProcessFurther)
         }

--- a/src/commonTest/kotlin/org/intellij/markdown/CommonMarkSpecTest.kt
+++ b/src/commonTest/kotlin/org/intellij/markdown/CommonMarkSpecTest.kt
@@ -3322,14 +3322,12 @@ class CommonMarkSpecTest : SpecTest(org.intellij.markdown.flavours.commonmark.Co
     )
 
     @Test
-    @Ignore
     fun testLinksExample541() = doTest(
             markdown = "[foo] [bar]\n\n[bar]: /url \"title\"\n",
             html = "<p>[foo] <a href=\"/url\" title=\"title\">bar</a></p>\n"
     )
 
     @Test
-    @Ignore
     fun testLinksExample542() = doTest(
             markdown = "[foo]\n[bar]\n\n[bar]: /url \"title\"\n",
             html = "<p>[foo]\n<a href=\"/url\" title=\"title\">bar</a></p>\n"

--- a/src/fileBasedTest/resources/data/parser/ea79689.md
+++ b/src/fileBasedTest/resources/data/parser/ea79689.md
@@ -1,2 +1,1 @@
-[**-f**|**--filter**[=*[]*]]
-[**--format**=*"TEMPLATE"*]
+[**-f**|**--filter**[=*[]*]][**--format**=*"TEMPLATE"*]

--- a/src/fileBasedTest/resources/data/parser/ea79689.txt
+++ b/src/fileBasedTest/resources/data/parser/ea79689.txt
@@ -25,7 +25,6 @@ Markdown:MARKDOWN_FILE
           Markdown:EMPH('*')
         Markdown:](']')
         Markdown:](']')
-      Markdown:EOL('\n')
       Markdown:LINK_LABEL
         Markdown:[('[')
         Markdown:STRONG

--- a/src/fileBasedTest/resources/data/parser/referenceLinks.md
+++ b/src/fileBasedTest/resources/data/parser/referenceLinks.md
@@ -2,8 +2,7 @@
 
 [*foo\!*][bar]
 
-> [foo]
-[bar]
+> [foo][bar]
 
 [link [foo [bar]]][ref]
 
@@ -17,9 +16,14 @@
 
 [*foo* bar][]
 
-[foo]
-[]
+[foo][]
 
 [*foo* bar]
 
 [[*foo* bar]]
+
+[foo]`bar`[baz]
+
+[foo]`bar`[baz]`qux`[quux]
+
+[foo] [bar][baz]

--- a/src/fileBasedTest/resources/data/parser/referenceLinks.txt
+++ b/src/fileBasedTest/resources/data/parser/referenceLinks.txt
@@ -34,7 +34,6 @@ Markdown:MARKDOWN_FILE
           Markdown:[('[')
           Markdown:TEXT('foo')
           Markdown:](']')
-        Markdown:EOL('\n')
         Markdown:LINK_LABEL
           Markdown:[('[')
           Markdown:TEXT('bar')
@@ -131,7 +130,6 @@ Markdown:MARKDOWN_FILE
         Markdown:[('[')
         Markdown:TEXT('foo')
         Markdown:](']')
-      Markdown:EOL('\n')
       Markdown:[('[')
       Markdown:](']')
   Markdown:EOL('\n')
@@ -162,3 +160,64 @@ Markdown:MARKDOWN_FILE
         Markdown:TEXT('bar')
         Markdown:](']')
     Markdown:](']')
+  Markdown:EOL('\n')
+  Markdown:EOL('\n')
+  Markdown:PARAGRAPH
+    Markdown:SHORT_REFERENCE_LINK
+      Markdown:LINK_LABEL
+        Markdown:[('[')
+        Markdown:TEXT('foo')
+        Markdown:](']')
+    Markdown:CODE_SPAN
+      Markdown:BACKTICK('`')
+      Markdown:TEXT('bar')
+      Markdown:BACKTICK('`')
+    Markdown:SHORT_REFERENCE_LINK
+      Markdown:LINK_LABEL
+        Markdown:[('[')
+        Markdown:TEXT('baz')
+        Markdown:](']')
+  Markdown:EOL('\n')
+  Markdown:EOL('\n')
+  Markdown:PARAGRAPH
+    Markdown:SHORT_REFERENCE_LINK
+      Markdown:LINK_LABEL
+        Markdown:[('[')
+        Markdown:TEXT('foo')
+        Markdown:](']')
+    Markdown:CODE_SPAN
+      Markdown:BACKTICK('`')
+      Markdown:TEXT('bar')
+      Markdown:BACKTICK('`')
+    Markdown:SHORT_REFERENCE_LINK
+      Markdown:LINK_LABEL
+        Markdown:[('[')
+        Markdown:TEXT('baz')
+        Markdown:](']')
+    Markdown:CODE_SPAN
+      Markdown:BACKTICK('`')
+      Markdown:TEXT('qux')
+      Markdown:BACKTICK('`')
+    Markdown:SHORT_REFERENCE_LINK
+      Markdown:LINK_LABEL
+        Markdown:[('[')
+        Markdown:TEXT('quux')
+        Markdown:](']')
+  Markdown:EOL('\n')
+  Markdown:EOL('\n')
+  Markdown:PARAGRAPH
+    Markdown:SHORT_REFERENCE_LINK
+      Markdown:LINK_LABEL
+        Markdown:[('[')
+        Markdown:TEXT('foo')
+        Markdown:](']')
+    WHITE_SPACE(' ')
+    Markdown:FULL_REFERENCE_LINK
+      Markdown:LINK_TEXT
+        Markdown:[('[')
+        Markdown:TEXT('bar')
+        Markdown:](']')
+      Markdown:LINK_LABEL
+        Markdown:[('[')
+        Markdown:TEXT('baz')
+        Markdown:](']')


### PR DESCRIPTION
The cause is that `TokenCache.RangesListIterator` skips indexes between text ranges without informing the user. So, we don't know whether the two tokens between an advance is right next to each other without an additional check.

The change to `ReferenceLinkParser` is, for both full and short reference links, they now check whether the opening bracket of the link label is right next to the closing bracket of the link text.

This change effectively disables the behavior that allows a newline between the link text and its label, so it is removed. The tests from `ea79689` and `referenceLinks` use this behavior, so they are also changed. This behavior is explicitly prohibited according to the spec, too:
https://spec.commonmark.org/0.31.2/#example-543
https://spec.commonmark.org/0.31.2/#example-556

Some new tests were added to `referenceLinks` to check the fixed behavior, and the relevant ignored spec tests were re-enabled.

Only the tests from `gradlew mingwX64Test` were checked since all other platforms failed most tests for an unknown reason, even for the current head.

This will fix [KTIJ-35552](https://youtrack.jetbrains.com/issue/KTIJ-35552) and the original Dokka issue Kotlin/Dokka#4234.

While this also fixes [KTIJ-35278](https://youtrack.jetbrains.com/issue/KTIJ-35278), it should be closed and reopened as another issue for the second case(no space between unlabeled and labeled link) as the current parsing system does not consider link destinations when parsing the links.