### PR TITLE
Fix variable name in Markdown parsing example

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ val html = HtmlGenerator(src, parsedTree, flavour).generateHtml()
 ```java
 final String src = "Some *Markdown*";
 final MarkdownFlavourDescriptor flavour = new GFMFlavourDescriptor();
-final ASTNode parsedTree = new MarkdownParser(flavour).buildMarkdownTreeFromString(text);
+final ASTNode parsedTree = new MarkdownParser(flavour).buildMarkdownTreeFromString(src);
 final String html = new HtmlGenerator(src, parsedTree, flavour, false).generateHtml();
 ```
 


### PR DESCRIPTION
## Summary
This PR corrects a variable name in the Markdown parsing example within README.md. The original example used `text` as the input string, while the actual variable declared was `src`. This fix ensures consistency between the declared variable and its usage in the parsing logic.

## Changes Made
Replaced `text` with `src` in the `buildMarkdownTreeFromString` method call