### PR TITLE
IJPL-236949 Fix HTML block parsing at EOF after a trailing blank line…

### DIFF
--- a/src/commonMain/kotlin/org/intellij/markdown/parser/markerblocks/MarkdownParserUtil.kt
+++ b/src/commonMain/kotlin/org/intellij/markdown/parser/markerblocks/MarkdownParserUtil.kt
@@ -23,7 +23,7 @@ object MarkdownParserUtil {
 
         while (isClearLine(currentPos)) {
             currentPos = currentPos.nextLinePosition()
-                    ?: break//return 5
+                    ?: return result + 1 // EOF after a blank line counts as another blank
 
             result++
             if (result > 4) {

--- a/src/fileBasedTest/kotlin/org/intellij/markdown/HtmlGeneratorCommonTest.kt
+++ b/src/fileBasedTest/kotlin/org/intellij/markdown/HtmlGeneratorCommonTest.kt
@@ -199,11 +199,11 @@ class HtmlGeneratorCommonTest : HtmlGeneratorTestBase() {
     fun testHtmlBlockZeroLengthNodeAtEof() {
         val md = "-         <tag>\n" +
                  " "  // single trailing space, no newline
-        try {
-            generateHtmlFromString(md)
-        } catch (t: Throwable) {
-            fail("Expected to parse without exception, got: $t")
-        }
+        val expectedHtml = """
+             <body><ul><li><pre><code>    &lt;tag&gt;
+             </code></pre></li></ul></body>
+         """.trimIndent()
+        assertEqualsIgnoreLines(expectedHtml, generateHtmlFromString(md))
     }
 
     @Test

--- a/src/fileBasedTest/kotlin/org/intellij/markdown/HtmlGeneratorCommonTest.kt
+++ b/src/fileBasedTest/kotlin/org/intellij/markdown/HtmlGeneratorCommonTest.kt
@@ -196,6 +196,17 @@ class HtmlGeneratorCommonTest : HtmlGeneratorTestBase() {
     }
 
     @Test
+    fun testHtmlBlockZeroLengthNodeAtEof() {
+        val md = "-         <tag>\n" +
+                 " "  // single trailing space, no newline
+        try {
+            generateHtmlFromString(md)
+        } catch (t: Throwable) {
+            fail("Expected to parse without exception, got: $t")
+        }
+    }
+
+    @Test
     fun testXssProtection() {
         val disallowedLinkMd1 = "[Click me](javascript:alert(document.domain))"
         val disallowedLinkMd2 = "[Click me](file:///123)"

--- a/src/fileBasedTest/resources/data/html/htmlBlocks.txt
+++ b/src/fileBasedTest/resources/data/html/htmlBlocks.txt
@@ -84,5 +84,4 @@ foo
 </blockquote>
 <div class
 foo
-
 </body>


### PR DESCRIPTION
**Issue**: [IJPL-236949](https://youtrack.jetbrains.com/issue/IJPL-236949) Markdown File cannot be opened in IntelliJ
**Root cause**: `calcNumberOfConsequentEols` counts consecutive blank lines to decide when to close an HTML block (threshold ≥ 2). When the last line is blank/whitespace-only, `nextLinePosition()` returns `null`, and the old `?: break` fired before incrementing result — returning 1 instead of 2. The block stayed open.
**Consequence**: With input like `-         <tag>\n ` (a list item with an HTML block + trailing space at EOF), the still-open block then tried to emit an `HTML_BLOCK_CONTENT` node at `start == end == EOF`, landing outside `MARKDOWN_FILE` and throwing `MarkdownParsingException: more than one root?`.
**Fix**: `?: return result + 1 ` — EOF after a blank line counts as a second blank, so the block terminates correctly before emitting any content from the trailing line.