### PR TITLE
feat: streaming markdown parser

### DIFF
--- a/src/commonMain/kotlin/org/intellij/markdown/ExperimentalApi.kt
+++ b/src/commonMain/kotlin/org/intellij/markdown/ExperimentalApi.kt
@@ -9,5 +9,5 @@ package org.intellij.markdown
   level = RequiresOptIn.Level.ERROR
 )
 @Retention(AnnotationRetention.BINARY)
-@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION, AnnotationTarget.CONSTRUCTOR)
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION, AnnotationTarget.CONSTRUCTOR, AnnotationTarget.PROPERTY)
 annotation class ExperimentalApi

--- a/src/commonMain/kotlin/org/intellij/markdown/ast/ASTNodeBuilder.kt
+++ b/src/commonMain/kotlin/org/intellij/markdown/ast/ASTNodeBuilder.kt
@@ -10,13 +10,20 @@ import org.intellij.markdown.parser.CancellationToken
 
 open class ASTNodeBuilder @ExperimentalApi constructor(
     protected val text: CharSequence,
-    protected val cancellationToken: CancellationToken
+    protected val cancellationToken: CancellationToken,
+    private val baseOffset: Int
 ) {
     /**
      * For compatibility only.
      */
     @OptIn(ExperimentalApi::class)
     constructor(text: CharSequence): this(text, CancellationToken.NonCancellable)
+
+    /**
+     * For ABI compatibility.
+     */
+    @OptIn(ExperimentalApi::class)
+    constructor(text: CharSequence, cancellationToken: CancellationToken): this(text, cancellationToken, 0)
 
     @OptIn(ExperimentalApi::class)
     open fun createLeafNodes(type: IElementType, startOffset: Int, endOffset: Int): List<ASTNode> {
@@ -32,18 +39,18 @@ open class ASTNodeBuilder @ExperimentalApi constructor(
                 }
 
                 if (nextEol > lastEol) {
-                    result.add(LeafASTNode(MarkdownTokenTypes.WHITE_SPACE, lastEol, nextEol))
+                    result.add(LeafASTNode(MarkdownTokenTypes.WHITE_SPACE, lastEol + baseOffset, nextEol + baseOffset))
                 }
-                result.add(LeafASTNode(MarkdownTokenTypes.EOL, nextEol, nextEol + 1))
+                result.add(LeafASTNode(MarkdownTokenTypes.EOL, nextEol + baseOffset, nextEol + 1 + baseOffset))
                 lastEol = nextEol + 1
             }
             if (endOffset > lastEol) {
-                result.add(LeafASTNode(MarkdownTokenTypes.WHITE_SPACE, lastEol, endOffset))
+                result.add(LeafASTNode(MarkdownTokenTypes.WHITE_SPACE, lastEol + baseOffset, endOffset + baseOffset))
             }
 
             return result
         }
-        return listOf(LeafASTNode(type, startOffset, endOffset))
+        return listOf(LeafASTNode(type, startOffset + baseOffset, endOffset + baseOffset))
     }
 
     @OptIn(ExperimentalApi::class)

--- a/src/commonMain/kotlin/org/intellij/markdown/parser/MarkdownParser.kt
+++ b/src/commonMain/kotlin/org/intellij/markdown/parser/MarkdownParser.kt
@@ -7,6 +7,7 @@ import org.intellij.markdown.ast.CompositeASTNode
 import org.intellij.markdown.ast.LeafASTNode
 import org.intellij.markdown.flavours.MarkdownFlavourDescriptor
 import org.intellij.markdown.flavours.gfm.GFMTokenTypes
+import org.intellij.markdown.parser.markerblocks.MarkerBlock
 import org.intellij.markdown.parser.sequentialparsers.LexerBasedTokensCache
 import org.intellij.markdown.parser.sequentialparsers.SequentialParser
 import org.intellij.markdown.parser.sequentialparsers.SequentialParserUtil
@@ -58,7 +59,32 @@ class MarkdownParser @ExperimentalApi constructor(
             if (assertionsEnabled)
                 throw e
             else
-                inlineFallback(root, textStart, textEnd)
+                inlineFallback(root, textStart, textEnd, baseOffset)
+        }
+    }
+
+    // To keep the ABI compatibility.
+    fun parseInline(root: IElementType, text: CharSequence, textStart: Int, textEnd: Int): ASTNode {
+        return parseInline(root, text, textStart, textEnd, 0)
+    }
+
+    internal fun parseStreaming(root: IElementType, text: String, parseInlines: Boolean, baseOffset: Int): StreamingMarkdownParseResult {
+        return try {
+            val (tree, openMarkers) = doParse(root, text, parseInlines, baseOffset)
+            StreamingMarkdownParseResult(
+                tree = tree,
+                unstableStartOffset = findUnstableStartOffset(openMarkers, text, baseOffset)
+            )
+        }
+        catch (e: MarkdownParsingException) {
+            if (assertionsEnabled) {
+                throw e
+            } else {
+                StreamingMarkdownParseResult(
+                    tree = topLevelFallback(root, text, baseOffset),
+                    unstableStartOffset = baseOffset
+                )
+            }
         }
     }
 
@@ -82,6 +108,9 @@ class MarkdownParser @ExperimentalApi constructor(
             pos = markerProcessor.processPosition(pos)
         }
 
+        // Take a snapshot before flush
+        val openMarkers = markerProcessor.markersStackSnapshot
+
         productionHolder.updatePosition(text.length)
         markerProcessor.flushMarkers()
 
@@ -95,7 +124,24 @@ class MarkdownParser @ExperimentalApi constructor(
 
         val builder = TopLevelBuilder(nodeBuilder)
 
-        return builder.buildTree(productionHolder.production)
+        return MarkdownParseResult(
+            tree = builder.buildTree(productionHolder.production),
+            openMarkers = openMarkers
+        )
+    }
+
+    private fun findUnstableStartOffset(
+        openMarkers: List<MarkerBlock>,
+        text: String,
+        baseOffset: Int
+    ): Int {
+        var unstableStartOffset = text.length
+        @OptIn(ExperimentalApi::class)
+        val firstOpenMarkerOffset = openMarkers.minOfOrNull { it.startOffset }
+        firstOpenMarkerOffset?.let { unstableStartOffset = minOf(it, unstableStartOffset) }
+        val lastLineStartOffset = text.lastIndexOf('\n') + 1
+        unstableStartOffset = minOf(lastLineStartOffset, unstableStartOffset)
+        return unstableStartOffset + baseOffset
     }
 
     @OptIn(ExperimentalApi::class)
@@ -139,10 +185,20 @@ class MarkdownParser @ExperimentalApi constructor(
                 MarkdownTokenTypes.ATX_CONTENT,
                 MarkdownTokenTypes.SETEXT_CONTENT,
                 GFMTokenTypes.CELL ->
-                    listOf(parseInline(type, text, startOffset, endOffset))
+                    listOf(parseInline(type, text, startOffset, endOffset, baseOffset))
                 else ->
                     super.createLeafNodes(type, startOffset, endOffset)
             }
         }
     }
 }
+
+internal data class MarkdownParseResult(
+    val tree: ASTNode,
+    val openMarkers: List<MarkerBlock>
+)
+
+internal data class StreamingMarkdownParseResult(
+    val tree: ASTNode,
+    val unstableStartOffset: Int
+)

--- a/src/commonMain/kotlin/org/intellij/markdown/parser/MarkdownParser.kt
+++ b/src/commonMain/kotlin/org/intellij/markdown/parser/MarkdownParser.kt
@@ -130,6 +130,12 @@ class MarkdownParser @ExperimentalApi constructor(
         )
     }
 
+    /**
+     * This handles 2 cases:
+     *
+     * For code blocks/HTML blocks, the internal [MarkerBlock]s are snapshoted before [MarkerProcessor.flushMarkers] to find the unenclosed block and decide the unstable boundary.
+     * For other cases, the last blank line is used to decide the unstable boundary.
+     */
     private fun findUnstableStartOffset(
         openMarkers: List<MarkerBlock>,
         text: String,
@@ -139,9 +145,20 @@ class MarkdownParser @ExperimentalApi constructor(
         @OptIn(ExperimentalApi::class)
         val firstOpenMarkerOffset = openMarkers.minOfOrNull { it.startOffset }
         firstOpenMarkerOffset?.let { unstableStartOffset = minOf(it, unstableStartOffset) }
-        val lastLineStartOffset = text.lastIndexOf('\n') + 1
-        unstableStartOffset = minOf(lastLineStartOffset, unstableStartOffset)
+        val lastBlankLineEnd = text.lastBlankLineEndOrNull() ?: 0
+        unstableStartOffset = minOf(lastBlankLineEnd, unstableStartOffset)
         return unstableStartOffset + baseOffset
+    }
+
+    /**
+     * Return the exclusive end of the last blank line in the string.
+     * This guarantees O(1) memory usage and O(n) worst-case time complexity.
+     */
+    private tailrec fun String.lastBlankLineEndOrNull(lineEnd: Int = lastIndexOf('\n')): Int? {
+        val lastLineEnd = lastIndexOf('\n', lineEnd - 1)
+        if (lastLineEnd == -1) return null
+        if ((lastLineEnd..lineEnd).all { this[it].isWhitespace() }) return lineEnd + 1
+        return lastBlankLineEndOrNull(lastLineEnd)
     }
 
     @OptIn(ExperimentalApi::class)

--- a/src/commonMain/kotlin/org/intellij/markdown/parser/MarkdownParser.kt
+++ b/src/commonMain/kotlin/org/intellij/markdown/parser/MarkdownParser.kt
@@ -24,25 +24,35 @@ class MarkdownParser @ExperimentalApi constructor(
         assertionsEnabled: Boolean
     ): this(flavour, assertionsEnabled, CancellationToken.NonCancellable)
 
-    fun buildMarkdownTreeFromString(text: String): ASTNode {
-        return parse(MarkdownElementTypes.MARKDOWN_FILE, text, true)
+    fun buildMarkdownTreeFromString(text: String, baseOffset: Int): ASTNode {
+        return parse(MarkdownElementTypes.MARKDOWN_FILE, text, true, baseOffset)
     }
 
-    fun parse(root: IElementType, text: String, parseInlines: Boolean = true): ASTNode {
+    // To keep the ABI compatibility.
+    fun buildMarkdownTreeFromString(text: String): ASTNode {
+        return buildMarkdownTreeFromString(text, 0)
+    }
+
+    fun parse(root: IElementType, text: String, parseInlines: Boolean, baseOffset: Int): ASTNode {
         return try {
-            doParse(root, text, parseInlines)
+            doParse(root, text, parseInlines, baseOffset).tree
         }
         catch (e: MarkdownParsingException) {
             if (assertionsEnabled)
                 throw e
             else
-                topLevelFallback(root, text)
+                topLevelFallback(root, text, baseOffset)
         }
     }
 
-    fun parseInline(root: IElementType, text: CharSequence, textStart: Int, textEnd: Int): ASTNode {
+    // To keep the ABI compatibility.
+    fun parse(root: IElementType, text: String, parseInlines: Boolean = true): ASTNode {
+        return parse(root, text, parseInlines, 0)
+    }
+
+    fun parseInline(root: IElementType, text: CharSequence, textStart: Int, textEnd: Int, baseOffset: Int): ASTNode {
         return try {
-            doParseInline(root, text, textStart, textEnd)
+            doParseInline(root, text, textStart, textEnd, baseOffset)
         }
         catch (e: MarkdownParsingException) {
             if (assertionsEnabled)
@@ -53,7 +63,12 @@ class MarkdownParser @ExperimentalApi constructor(
     }
 
     @OptIn(ExperimentalApi::class)
-    private fun doParse(root: IElementType, text: String, parseInlines: Boolean = true): ASTNode {
+    private fun doParse(
+        root: IElementType,
+        text: String,
+        parseInlines: Boolean = true,
+        baseOffset: Int = 0
+    ): MarkdownParseResult {
         val productionHolder = ProductionHolder()
         val markerProcessor = flavour.markerProcessorFactory.createMarkerProcessor(productionHolder)
 
@@ -73,9 +88,9 @@ class MarkdownParser @ExperimentalApi constructor(
         rootMarker.done(root)
 
         val nodeBuilder = if (parseInlines) {
-            InlineExpandingASTNodeBuilder(text)
+            InlineExpandingASTNodeBuilder(text, baseOffset)
         } else {
-            ASTNodeBuilder(text)
+            ASTNodeBuilder(text, cancellationToken, baseOffset)
         }
 
         val builder = TopLevelBuilder(nodeBuilder)
@@ -84,7 +99,7 @@ class MarkdownParser @ExperimentalApi constructor(
     }
 
     @OptIn(ExperimentalApi::class)
-    private fun doParseInline(root: IElementType, text: CharSequence, textStart: Int, textEnd: Int): ASTNode {
+    private fun doParseInline(root: IElementType, text: CharSequence, textStart: Int, textEnd: Int, baseOffset: Int = 0): ASTNode {
         val lexer = flavour.createInlinesLexer()
         lexer.start(text, textStart, textEnd)
         val tokensCache = LexerBasedTokensCache(lexer)
@@ -96,24 +111,28 @@ class MarkdownParser @ExperimentalApi constructor(
             cancellationToken = cancellationToken
         )
 
-        val builder = InlineBuilder(ASTNodeBuilder(text, cancellationToken), tokensCache, cancellationToken)
+        val builder = InlineBuilder(ASTNodeBuilder(text, cancellationToken, baseOffset), tokensCache, cancellationToken)
         return builder.buildTree(nodes + listOf(SequentialParser.Node(wholeRange, root)))
     }
 
-    private fun topLevelFallback(root: IElementType, text: String): ASTNode {
+    private fun topLevelFallback(root: IElementType, text: String, baseOffset: Int): ASTNode {
         return CompositeASTNode(
-            root, listOf(inlineFallback(MarkdownElementTypes.PARAGRAPH, 0, text.length))
+            root, listOf(inlineFallback(MarkdownElementTypes.PARAGRAPH, 0, text.length, baseOffset))
         )
     }
 
-    private fun inlineFallback(root: IElementType, textStart: Int, textEnd: Int): ASTNode {
+    private fun inlineFallback(root: IElementType, textStart: Int, textEnd: Int, baseOffset: Int): ASTNode {
         return CompositeASTNode(
             root,
-            listOf(LeafASTNode(MarkdownTokenTypes.TEXT, textStart, textEnd))
+            listOf(LeafASTNode(MarkdownTokenTypes.TEXT, textStart + baseOffset, textEnd + baseOffset))
         )
     }
 
-    private inner class InlineExpandingASTNodeBuilder(text: CharSequence) : ASTNodeBuilder(text) {
+    @OptIn(ExperimentalApi::class)
+    private inner class InlineExpandingASTNodeBuilder(
+        text: CharSequence,
+        private val baseOffset: Int
+    ) : ASTNodeBuilder(text, cancellationToken, baseOffset) {
         override fun createLeafNodes(type: IElementType, startOffset: Int, endOffset: Int): List<ASTNode> {
             return when (type) {
                 MarkdownElementTypes.PARAGRAPH,

--- a/src/commonMain/kotlin/org/intellij/markdown/parser/MarkerProcessor.kt
+++ b/src/commonMain/kotlin/org/intellij/markdown/parser/MarkerProcessor.kt
@@ -14,6 +14,9 @@ abstract class MarkerProcessor<T : MarkerProcessor.StateInfo>(private val produc
 
     protected val markersStack: MutableList<MarkerBlock> = ArrayList()
 
+    internal val markersStackSnapshot: List<MarkerBlock>
+        get() = markersStack.toList()
+
     protected var topBlockConstraints: MarkdownConstraints = startConstraints
 
     protected abstract val stateInfo: T

--- a/src/commonMain/kotlin/org/intellij/markdown/parser/ProductionHolder.kt
+++ b/src/commonMain/kotlin/org/intellij/markdown/parser/ProductionHolder.kt
@@ -26,7 +26,7 @@ class ProductionHolder {
     }
 
     inner class Marker {
-        private val startPos: Int = currentPosition
+        internal val startPos: Int = currentPosition
 
         fun done(type: IElementType) {
             _production.add(SequentialParser.Node(startPos..currentPosition, type))

--- a/src/commonMain/kotlin/org/intellij/markdown/parser/StreamingMarkdownFile.kt
+++ b/src/commonMain/kotlin/org/intellij/markdown/parser/StreamingMarkdownFile.kt
@@ -1,0 +1,111 @@
+package org.intellij.markdown.parser
+
+import org.intellij.markdown.IElementType
+import org.intellij.markdown.MarkdownElementTypes.MARKDOWN_FILE
+import org.intellij.markdown.ast.ASTNode
+import org.intellij.markdown.flavours.MarkdownFlavourDescriptor
+import org.intellij.markdown.flavours.gfm.GFMFlavourDescriptor
+
+/**
+ * Mutable AST node that accept appending chunks.
+ *
+ * THIS INSTANCE IS NOT CONCURRENT SAFE. NEVER ACCESS IT CONCURRENTLY.
+ *
+ * When [append] is called, only the [unstableTail] part will be reparsed.
+ * The only way to update its state is to invoke [append].
+ * Then [endOffset], [stableChildren], [unstableTail] and [children] will be updated.
+ *
+ * To avoid memory leak, it doesn't hold the whole original Markdown string.
+ * The caller may accumulate the original string outside the [StreamingMarkdownFile].
+ *
+ * After each append, [StreamingMarkdownFile] represents a complete Markdown document ending at the current offset.
+ */
+interface StreamingMarkdownFile: ASTNode {
+    override val type : IElementType
+        get() = MARKDOWN_FILE
+    override val startOffset : Int
+        get() = 0
+    override val endOffset : Int
+    override val parent: Nothing?
+        get() = null
+    override val children : List<ASTNode>
+        get() = stableChildren + unstableTail
+
+    /**
+     * The accumulated stable part of the Markdown file.
+     *
+     * It's append-only, and the appended [ASTNode] will not be reparsed or replaced.
+     */
+    val stableChildren : List<ASTNode>
+
+    /**
+     * The unstable part of the Markdown file.
+     * It may be updated by [append]. Every [append] will reparse this part.
+     * If some part of [unstableTail] gets stable, it will be removed and appended to [stableChildren].
+     */
+    val unstableTail: List<ASTNode>
+
+    /**
+     * Appends a chunk of text to the current Markdown document.
+     *
+     * This method updates the internal state of the document by parsing the chunk
+     * and merging it into the unstable portion of the Markdown file. Once the append
+     * operation is completed, the document represents a fully parsed and updated
+     * Markdown structure ending at the current offset.
+     *
+     * Note: This method is not thread-safe and should not be called concurrently.
+     */
+    fun append(chunk: CharSequence)
+}
+
+@Suppress("FunctionName")
+fun EmptyStreamingMarkdownFile(
+    flavour: MarkdownFlavourDescriptor = GFMFlavourDescriptor(),
+): StreamingMarkdownFile = StreamingMarkdownFileImpl(MarkdownParser(flavour))
+
+private class StreamingMarkdownFileImpl(
+    private val parser: MarkdownParser,
+) : StreamingMarkdownFile {
+    // FIXME: use backing fields feature with Kotlin 2.3.0
+    private val stableChildrenBacking = mutableListOf<ASTNode>()
+    private var stableTextLength = 0
+    private val unstableText = StringBuilder()
+    // FIXME: use backing fields feature with Kotlin 2.3.0
+    private var unstableTailBacking: List<ASTNode> = emptyList()
+
+    override val endOffset: Int
+        get() = stableTextLength + unstableText.length
+
+    override val stableChildren: List<ASTNode>
+        get() = stableChildrenBacking
+
+    override val unstableTail: List<ASTNode>
+        get() = unstableTailBacking
+
+    override fun append(chunk: CharSequence) {
+        if (chunk.isEmpty()) {
+            return
+        }
+
+        unstableText.append(chunk)
+
+        val (unstableTree, unstableStartOffset) = parser.parseStreaming(
+            MARKDOWN_FILE,
+            unstableText.toString(),
+            parseInlines = true,
+            baseOffset = stableTextLength
+        )
+        val stableBoundary = unstableStartOffset - stableTextLength
+        if (stableBoundary > 0) {
+            val newStableChildren = unstableTree.children
+                .filter { it.endOffset <= stableTextLength + stableBoundary }
+            stableChildrenBacking.addAll(newStableChildren)
+            stableTextLength += stableBoundary
+            unstableText.deleteRange(0, stableBoundary)
+            unstableTailBacking = unstableTree.children
+                .filter { it.startOffset >= stableTextLength }
+        } else {
+            unstableTailBacking = unstableTree.children
+        }
+    }
+}

--- a/src/commonMain/kotlin/org/intellij/markdown/parser/markerblocks/MarkerBlock.kt
+++ b/src/commonMain/kotlin/org/intellij/markdown/parser/markerblocks/MarkerBlock.kt
@@ -1,11 +1,15 @@
 package org.intellij.markdown.parser.markerblocks
 
+import org.intellij.markdown.ExperimentalApi
 import org.intellij.markdown.IElementType
 import org.intellij.markdown.parser.LookaheadText
 import org.intellij.markdown.parser.ProductionHolder
 import org.intellij.markdown.parser.constraints.MarkdownConstraints
 
 interface MarkerBlock {
+
+    @ExperimentalApi
+    val startOffset: Int
 
     fun getNextInterestingOffset(pos: LookaheadText.Position): Int
 

--- a/src/commonMain/kotlin/org/intellij/markdown/parser/markerblocks/MarkerBlockImpl.kt
+++ b/src/commonMain/kotlin/org/intellij/markdown/parser/markerblocks/MarkerBlockImpl.kt
@@ -1,5 +1,6 @@
 package org.intellij.markdown.parser.markerblocks
 
+import org.intellij.markdown.ExperimentalApi
 import org.intellij.markdown.IElementType
 import org.intellij.markdown.parser.LookaheadText
 import org.intellij.markdown.parser.ProductionHolder
@@ -8,6 +9,10 @@ import org.intellij.markdown.parser.constraints.MarkdownConstraints
 
 abstract class MarkerBlockImpl(protected val constraints: MarkdownConstraints,
                                protected val marker: ProductionHolder.Marker) : MarkerBlock {
+
+    @ExperimentalApi
+    override val startOffset: Int
+        get() = marker.startPos
 
     private var lastInterestingOffset: Int = -2
 

--- a/src/commonTest/kotlin/org/intellij/markdown/parser/MarkdownParserOffsetTest.kt
+++ b/src/commonTest/kotlin/org/intellij/markdown/parser/MarkdownParserOffsetTest.kt
@@ -1,0 +1,36 @@
+package org.intellij.markdown.parser
+
+import org.intellij.markdown.MarkdownElementTypes
+import org.intellij.markdown.flavours.gfm.GFMFlavourDescriptor
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class MarkdownParserOffsetTest {
+    @Test
+    fun buildMarkdownTreeFromStringCanApplyBaseOffset() {
+        val tree = MarkdownParser(GFMFlavourDescriptor())
+            .buildMarkdownTreeFromString("world", 7)
+
+        val paragraph = tree.children.single()
+
+        assertEquals(MarkdownElementTypes.PARAGRAPH, paragraph.type)
+        assertEquals(7, paragraph.startOffset)
+        assertEquals(12, paragraph.endOffset)
+        assertEquals(7, paragraph.children.single().startOffset)
+        assertEquals(12, paragraph.children.single().endOffset)
+    }
+
+    @Test
+    fun parseCanApplyBaseOffset() {
+        val tree = MarkdownParser(GFMFlavourDescriptor())
+            .parse(MarkdownElementTypes.MARKDOWN_FILE, "world", parseInlines = true, baseOffset = 7)
+
+        val paragraph = tree.children.single()
+
+        assertEquals(MarkdownElementTypes.PARAGRAPH, paragraph.type)
+        assertEquals(7, paragraph.startOffset)
+        assertEquals(12, paragraph.endOffset)
+        assertEquals(7, paragraph.children.single().startOffset)
+        assertEquals(12, paragraph.children.single().endOffset)
+    }
+}

--- a/src/commonTest/kotlin/org/intellij/markdown/parser/StreamingMarkdownConsistencyTest.kt
+++ b/src/commonTest/kotlin/org/intellij/markdown/parser/StreamingMarkdownConsistencyTest.kt
@@ -1,0 +1,310 @@
+package org.intellij.markdown.parser
+
+import org.intellij.markdown.ast.ASTNode
+import org.intellij.markdown.flavours.gfm.GFMFlavourDescriptor
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class StreamingMarkdownConsistencyTest {
+    private val parser = MarkdownParser(GFMFlavourDescriptor())
+
+    @Test
+    fun streamingParseMatchesFullParseWithFixedChunks() {
+        assertStreamingMatchesFullParse(
+            name = "large document with fixed chunks",
+            text = LARGE_MARKDOWN_TEXT,
+            chunkSizes = listOf(1, 2, 3, 5, 8, 13, 21, 34)
+        )
+    }
+
+    @Test
+    fun streamingParseMatchesFullParseWithDeterministicPseudoRandomChunks() {
+        assertStreamingMatchesFullParse(
+            name = "large document with deterministic pseudo-random chunks",
+            text = LARGE_MARKDOWN_TEXT,
+            chunkSizes = pseudoRandomChunkSizes(LARGE_MARKDOWN_TEXT.length)
+        )
+    }
+
+    @Test
+    fun streamingParseMatchesFullParseWhenSetextHeadingArrivesLineByLine() {
+        val text = """
+            A heading
+            ---------
+
+            A paragraph after the heading.
+        """.trimIndent()
+        assertStreamingMatchesFullParse(
+            name = "setext heading line by line",
+            text = text,
+            chunkSizes = text.lineChunkSizes()
+        )
+    }
+
+    @Test
+    fun streamingParseMatchesFullParseWhenTableArrivesLineByLine() {
+        val text = """
+            | Name | Value |
+            | ---- | ----- |
+            | one  | **1** |
+            | two  | `2`   |
+        """.trimIndent()
+        assertStreamingMatchesFullParse(
+            name = "table line by line",
+            text = text,
+            chunkSizes = text.lineChunkSizes()
+        )
+    }
+
+    @Test
+    fun streamingParseMatchesFullParseWhenNestedListArrivesLineByLine() {
+        val text = """
+            - first item
+            - second item
+              - nested item
+            - third item
+        """.trimIndent()
+        assertStreamingMatchesFullParse(
+            name = "nested list line by line",
+            text = text,
+            chunkSizes = text.lineChunkSizes()
+        )
+    }
+
+    @Test
+    fun streamingParseMatchesFullParseWhenOrderedListArrivesLineByLine() {
+        val text = """
+            1. first item
+            2. second item
+            3. third item
+        """.trimIndent()
+        assertStreamingMatchesFullParse(
+            name = "ordered list line by line",
+            text = text,
+            chunkSizes = text.lineChunkSizes()
+        )
+    }
+
+    @Test
+    fun streamingParseMatchesFullParseWhenListItemContinuationArrivesLineByLine() {
+        val text = """
+            - first item
+              continuation of first item
+            - second item
+        """.trimIndent()
+        assertStreamingMatchesFullParse(
+            name = "list item continuation line by line",
+            text = text,
+            chunkSizes = text.lineChunkSizes()
+        )
+    }
+
+    @Test
+    fun streamingParseMatchesFullParseWhenBlockQuoteArrivesLineByLine() {
+        val text = """
+            > first quote line
+            > second quote line with *emphasis*
+
+            paragraph after quote
+        """.trimIndent()
+        assertStreamingMatchesFullParse(
+            name = "block quote line by line",
+            text = text,
+            chunkSizes = text.lineChunkSizes()
+        )
+    }
+
+    @Test
+    fun streamingParseMatchesFullParseWhenLazyBlockQuoteContinuationArrivesLineByLine() {
+        val text = """
+            > first quote line
+            lazy continuation line
+
+            paragraph after quote
+        """.trimIndent()
+        assertStreamingMatchesFullParse(
+            name = "lazy block quote continuation line by line",
+            text = text,
+            chunkSizes = text.lineChunkSizes()
+        )
+    }
+
+    @Test
+    fun streamingParseMatchesFullParseWhenCodeFenceArrivesLineByLine() {
+        val text = """
+            ```kotlin
+            fun answer(): Int {
+                return 42
+            }
+            ```
+
+            after fence
+        """.trimIndent()
+        assertStreamingMatchesFullParse(
+            name = "code fence line by line",
+            text = text,
+            chunkSizes = text.lineChunkSizes()
+        )
+    }
+
+    @Test
+    fun streamingParseMatchesFullParseWhenIndentedCodeBlockArrivesLineByLine() {
+        val text = """
+                first code line
+                second code line
+
+            paragraph after indented code
+        """.trimIndent()
+        assertStreamingMatchesFullParse(
+            name = "indented code block line by line",
+            text = text,
+            chunkSizes = text.lineChunkSizes()
+        )
+    }
+
+    @Test
+    fun streamingParseMatchesFullParseWhenHtmlBlockArrivesLineByLine() {
+        val text = """
+            <div>
+            text in html block
+            </div>
+
+            paragraph after html
+        """.trimIndent()
+        assertStreamingMatchesFullParse(
+            name = "html block line by line",
+            text = text,
+            chunkSizes = text.lineChunkSizes()
+        )
+    }
+
+    @Test
+    fun streamingParseMatchesFullParseWhenReferenceDefinitionArrivesAfterReferenceLink() {
+        val text = """
+            [JetBrains][jb]
+
+            [jb]: https://www.jetbrains.com
+        """.trimIndent()
+        assertStreamingMatchesFullParse(
+            name = "reference definition after reference link",
+            text = text,
+            chunkSizes = text.lineChunkSizes()
+        )
+    }
+
+    @Test
+    fun streamingParseMatchesFullParseWhenFormattedParagraphArrivesInSmallChunks() {
+        val text = """
+            This paragraph has **strong text**, _emphasis_, `inline code`, [a link](https://example.com),
+            and enough words to be split across several chunks without ending the paragraph too early.
+        """.trimIndent()
+        assertStreamingMatchesFullParse(
+            name = "formatted paragraph in small chunks",
+            text = text,
+            chunkSizes = listOf(4, 7, 2, 11, 5, 13)
+        )
+    }
+
+    private fun assertStreamingMatchesFullParse(name: String, text: String, chunkSizes: List<Int>) {
+        val file = EmptyStreamingMarkdownFile()
+        val consumedText = StringBuilder()
+        var offset = 0
+        var chunkIndex = 0
+        while (offset < text.length) {
+            val chunkSize = minOf(chunkSizes[chunkIndex % chunkSizes.size], text.length - offset)
+            val chunk = text.substring(offset, offset + chunkSize)
+            file.append(chunk)
+            consumedText.append(chunk)
+
+            val expectedTree = parser.buildMarkdownTreeFromString(consumedText.toString())
+            assertEquals(
+                expectedTree.children.toComparableTree(),
+                file.children.toComparableTree(),
+                "Streaming parse should match full parse for $name after consuming ${offset + chunkSize} chars with chunk '$chunk'"
+            )
+
+            offset += chunkSize
+            chunkIndex++
+        }
+    }
+
+    private fun pseudoRandomChunkSizes(length: Int): List<Int> {
+        var state = 17L
+        var remaining = length
+        val result = mutableListOf<Int>()
+        while (remaining > 0) {
+            state = state * 1103515245 + 12345
+            val size = (kotlin.math.abs(state) % 37 + 1).toInt()
+            result.add(minOf(size, remaining))
+            remaining -= size
+        }
+        return result
+    }
+
+    private fun String.lineChunkSizes(): List<Int> {
+        val result = mutableListOf<Int>()
+        var chunkStart = 0
+        for (index in indices) {
+            if (this[index] == '\n') {
+                result.add(index - chunkStart + 1)
+                chunkStart = index + 1
+            }
+        }
+        if (chunkStart < length) {
+            result.add(length - chunkStart)
+        }
+        return result
+    }
+
+    private fun List<ASTNode>.toComparableTree(): List<ComparableNode> {
+        return map { it.toComparableTree() }
+    }
+
+    private fun ASTNode.toComparableTree(): ComparableNode {
+        return ComparableNode(
+            type = type.toString(),
+            startOffset = startOffset,
+            endOffset = endOffset,
+            children = children.toComparableTree()
+        )
+    }
+
+    private data class ComparableNode(
+        val type: String,
+        val startOffset: Int,
+        val endOffset: Int,
+        val children: List<ComparableNode>
+    )
+
+    private companion object {
+        private val LARGE_MARKDOWN_TEXT = """
+            # Streaming parser consistency
+
+            This is a long paragraph with **strong text**, _emphasis_, `inline code`,
+            [an inline link](https://example.com), and enough words to cross many chunk
+            boundaries while still being a single paragraph in Markdown.
+
+            ## Lists and quotes
+
+            - first item with **bold**
+            - second item with `code`
+              - nested item with [link](https://kotlinlang.org)
+
+            > A block quote can contain *emphasis* and multiple lines.
+            > It should stay structurally equivalent when parsed through streaming chunks.
+
+            ```kotlin
+            fun answer(): Int {
+                return 42
+            }
+            ```
+
+            | Name | Value |
+            | ---- | ----- |
+            | one  | **1** |
+            | two  | `2`   |
+
+            A final paragraph without a trailing blank line, so the last append still has an unstable tail
+        """.trimIndent()
+    }
+}

--- a/src/commonTest/kotlin/org/intellij/markdown/parser/StreamingMarkdownConsistencyTest.kt
+++ b/src/commonTest/kotlin/org/intellij/markdown/parser/StreamingMarkdownConsistencyTest.kt
@@ -2,6 +2,7 @@ package org.intellij.markdown.parser
 
 import org.intellij.markdown.ast.ASTNode
 import org.intellij.markdown.flavours.gfm.GFMFlavourDescriptor
+import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -215,12 +216,11 @@ class StreamingMarkdownConsistencyTest {
     }
 
     private fun pseudoRandomChunkSizes(length: Int): List<Int> {
-        var state = 17L
+        val random = Random(17)
         var remaining = length
         val result = mutableListOf<Int>()
         while (remaining > 0) {
-            state = state * 1103515245 + 12345
-            val size = (kotlin.math.abs(state) % 37 + 1).toInt()
+            val size = random.nextInt(from = 1, until = 38)
             result.add(minOf(size, remaining))
             remaining -= size
         }

--- a/src/commonTest/kotlin/org/intellij/markdown/parser/StreamingMarkdownConsistencyTest.kt
+++ b/src/commonTest/kotlin/org/intellij/markdown/parser/StreamingMarkdownConsistencyTest.kt
@@ -153,11 +153,18 @@ class StreamingMarkdownConsistencyTest {
     }
 
     @Test
-    fun htmlBlockArrivesLineByLine() {
+    fun htmlBlocksArriveLineByLine() {
         val text = """
             <div>
             text in html block
             </div>
+
+            <!-- html comment block
+            with another line -->
+
+            <table>
+            <tr><td>cell</td></tr>
+            </table>
 
             paragraph after html
         """.trimIndent()
@@ -189,6 +196,18 @@ class StreamingMarkdownConsistencyTest {
         assertStreamingMatchesFullParse(
             text = text,
             chunkSizes = listOf(4, 7, 2, 11, 5, 13)
+        )
+    }
+
+    @Test
+    fun inlineHtmlArrivesInSmallChunks() {
+        val text = """
+            This paragraph has <span class="note">inline <strong>HTML</strong></span>,
+            a self closing <br /> tag, and **markdown** around it.
+        """.trimIndent()
+        assertStreamingMatchesFullParse(
+            text = text,
+            chunkSizes = listOf(3, 5, 2, 7, 11)
         )
     }
 
@@ -268,7 +287,8 @@ class StreamingMarkdownConsistencyTest {
 
             This is a long paragraph with **strong text**, _emphasis_, `inline code`,
             [an inline link](https://example.com), and enough words to cross many chunk
-            boundaries while still being a single paragraph in Markdown.
+            boundaries while still being a single paragraph in Markdown. It also has
+            <span data-kind="inline">inline HTML</span>.
 
             ## Lists and quotes
 
@@ -289,6 +309,10 @@ class StreamingMarkdownConsistencyTest {
             | ---- | ----- |
             | one  | **1** |
             | two  | `2`   |
+
+            <section>
+            Raw HTML block content with <em>inline tag</em>.
+            </section>
 
             A final paragraph without a trailing blank line, so the last append still has an unstable tail
         """.trimIndent()

--- a/src/commonTest/kotlin/org/intellij/markdown/parser/StreamingMarkdownConsistencyTest.kt
+++ b/src/commonTest/kotlin/org/intellij/markdown/parser/StreamingMarkdownConsistencyTest.kt
@@ -11,7 +11,6 @@ class StreamingMarkdownConsistencyTest {
     @Test
     fun fixedChunks() {
         assertStreamingMatchesFullParse(
-            name = "large document with fixed chunks",
             text = LARGE_MARKDOWN_TEXT,
             chunkSizes = listOf(1, 2, 3, 5, 8, 13, 21, 34)
         )
@@ -20,7 +19,6 @@ class StreamingMarkdownConsistencyTest {
     @Test
     fun deterministicPseudoRandomChunks() {
         assertStreamingMatchesFullParse(
-            name = "large document with deterministic pseudo-random chunks",
             text = LARGE_MARKDOWN_TEXT,
             chunkSizes = pseudoRandomChunkSizes(LARGE_MARKDOWN_TEXT.length)
         )
@@ -35,7 +33,6 @@ class StreamingMarkdownConsistencyTest {
             A paragraph after the heading.
         """.trimIndent()
         assertStreamingMatchesFullParse(
-            name = "setext heading line by line",
             text = text,
             chunkSizes = text.lineChunkSizes()
         )
@@ -50,7 +47,6 @@ class StreamingMarkdownConsistencyTest {
             | two  | `2`   |
         """.trimIndent()
         assertStreamingMatchesFullParse(
-            name = "table line by line",
             text = text,
             chunkSizes = text.lineChunkSizes()
         )
@@ -65,7 +61,6 @@ class StreamingMarkdownConsistencyTest {
             - third item
         """.trimIndent()
         assertStreamingMatchesFullParse(
-            name = "nested list line by line",
             text = text,
             chunkSizes = text.lineChunkSizes()
         )
@@ -79,7 +74,6 @@ class StreamingMarkdownConsistencyTest {
             3. third item
         """.trimIndent()
         assertStreamingMatchesFullParse(
-            name = "ordered list line by line",
             text = text,
             chunkSizes = text.lineChunkSizes()
         )
@@ -93,7 +87,6 @@ class StreamingMarkdownConsistencyTest {
             - second item
         """.trimIndent()
         assertStreamingMatchesFullParse(
-            name = "list item continuation line by line",
             text = text,
             chunkSizes = text.lineChunkSizes()
         )
@@ -108,7 +101,6 @@ class StreamingMarkdownConsistencyTest {
             paragraph after quote
         """.trimIndent()
         assertStreamingMatchesFullParse(
-            name = "block quote line by line",
             text = text,
             chunkSizes = text.lineChunkSizes()
         )
@@ -123,7 +115,6 @@ class StreamingMarkdownConsistencyTest {
             paragraph after quote
         """.trimIndent()
         assertStreamingMatchesFullParse(
-            name = "lazy block quote continuation line by line",
             text = text,
             chunkSizes = text.lineChunkSizes()
         )
@@ -141,7 +132,6 @@ class StreamingMarkdownConsistencyTest {
             after fence
         """.trimIndent()
         assertStreamingMatchesFullParse(
-            name = "code fence line by line",
             text = text,
             chunkSizes = text.lineChunkSizes()
         )
@@ -156,7 +146,6 @@ class StreamingMarkdownConsistencyTest {
             paragraph after indented code
         """.trimIndent()
         assertStreamingMatchesFullParse(
-            name = "indented code block line by line",
             text = text,
             chunkSizes = text.lineChunkSizes()
         )
@@ -172,7 +161,6 @@ class StreamingMarkdownConsistencyTest {
             paragraph after html
         """.trimIndent()
         assertStreamingMatchesFullParse(
-            name = "html block line by line",
             text = text,
             chunkSizes = text.lineChunkSizes()
         )
@@ -186,7 +174,6 @@ class StreamingMarkdownConsistencyTest {
             [jb]: https://www.jetbrains.com
         """.trimIndent()
         assertStreamingMatchesFullParse(
-            name = "reference definition after reference link",
             text = text,
             chunkSizes = text.lineChunkSizes()
         )
@@ -199,13 +186,12 @@ class StreamingMarkdownConsistencyTest {
             and enough words to be split across several chunks without ending the paragraph too early.
         """.trimIndent()
         assertStreamingMatchesFullParse(
-            name = "formatted paragraph in small chunks",
             text = text,
             chunkSizes = listOf(4, 7, 2, 11, 5, 13)
         )
     }
 
-    private fun assertStreamingMatchesFullParse(name: String, text: String, chunkSizes: List<Int>) {
+    private fun assertStreamingMatchesFullParse(text: String, chunkSizes: List<Int>) {
         val file = EmptyStreamingMarkdownFile()
         val consumedText = StringBuilder()
         var offset = 0
@@ -220,7 +206,7 @@ class StreamingMarkdownConsistencyTest {
             assertEquals(
                 expectedTree.children.toComparableTree(),
                 file.children.toComparableTree(),
-                "Streaming parse should match full parse for $name after consuming ${offset + chunkSize} chars with chunk '$chunk'"
+                "Streaming parse should match full parse after consuming ${offset + chunkSize} chars with chunk '$chunk'"
             )
 
             offset += chunkSize

--- a/src/commonTest/kotlin/org/intellij/markdown/parser/StreamingMarkdownConsistencyTest.kt
+++ b/src/commonTest/kotlin/org/intellij/markdown/parser/StreamingMarkdownConsistencyTest.kt
@@ -9,7 +9,7 @@ class StreamingMarkdownConsistencyTest {
     private val parser = MarkdownParser(GFMFlavourDescriptor())
 
     @Test
-    fun streamingParseMatchesFullParseWithFixedChunks() {
+    fun fixedChunks() {
         assertStreamingMatchesFullParse(
             name = "large document with fixed chunks",
             text = LARGE_MARKDOWN_TEXT,
@@ -18,7 +18,7 @@ class StreamingMarkdownConsistencyTest {
     }
 
     @Test
-    fun streamingParseMatchesFullParseWithDeterministicPseudoRandomChunks() {
+    fun deterministicPseudoRandomChunks() {
         assertStreamingMatchesFullParse(
             name = "large document with deterministic pseudo-random chunks",
             text = LARGE_MARKDOWN_TEXT,
@@ -27,7 +27,7 @@ class StreamingMarkdownConsistencyTest {
     }
 
     @Test
-    fun streamingParseMatchesFullParseWhenSetextHeadingArrivesLineByLine() {
+    fun setextHeadingArrivesLineByLine() {
         val text = """
             A heading
             ---------
@@ -42,7 +42,7 @@ class StreamingMarkdownConsistencyTest {
     }
 
     @Test
-    fun streamingParseMatchesFullParseWhenTableArrivesLineByLine() {
+    fun tableArrivesLineByLine() {
         val text = """
             | Name | Value |
             | ---- | ----- |
@@ -57,7 +57,7 @@ class StreamingMarkdownConsistencyTest {
     }
 
     @Test
-    fun streamingParseMatchesFullParseWhenNestedListArrivesLineByLine() {
+    fun nestedListArrivesLineByLine() {
         val text = """
             - first item
             - second item
@@ -72,7 +72,7 @@ class StreamingMarkdownConsistencyTest {
     }
 
     @Test
-    fun streamingParseMatchesFullParseWhenOrderedListArrivesLineByLine() {
+    fun orderedListArrivesLineByLine() {
         val text = """
             1. first item
             2. second item
@@ -86,7 +86,7 @@ class StreamingMarkdownConsistencyTest {
     }
 
     @Test
-    fun streamingParseMatchesFullParseWhenListItemContinuationArrivesLineByLine() {
+    fun listItemContinuationArrivesLineByLine() {
         val text = """
             - first item
               continuation of first item
@@ -100,7 +100,7 @@ class StreamingMarkdownConsistencyTest {
     }
 
     @Test
-    fun streamingParseMatchesFullParseWhenBlockQuoteArrivesLineByLine() {
+    fun blockQuoteArrivesLineByLine() {
         val text = """
             > first quote line
             > second quote line with *emphasis*
@@ -115,7 +115,7 @@ class StreamingMarkdownConsistencyTest {
     }
 
     @Test
-    fun streamingParseMatchesFullParseWhenLazyBlockQuoteContinuationArrivesLineByLine() {
+    fun lazyBlockQuoteContinuationArrivesLineByLine() {
         val text = """
             > first quote line
             lazy continuation line
@@ -130,7 +130,7 @@ class StreamingMarkdownConsistencyTest {
     }
 
     @Test
-    fun streamingParseMatchesFullParseWhenCodeFenceArrivesLineByLine() {
+    fun codeFenceArrivesLineByLine() {
         val text = """
             ```kotlin
             fun answer(): Int {
@@ -148,7 +148,7 @@ class StreamingMarkdownConsistencyTest {
     }
 
     @Test
-    fun streamingParseMatchesFullParseWhenIndentedCodeBlockArrivesLineByLine() {
+    fun indentedCodeBlockArrivesLineByLine() {
         val text = """
                 first code line
                 second code line
@@ -163,7 +163,7 @@ class StreamingMarkdownConsistencyTest {
     }
 
     @Test
-    fun streamingParseMatchesFullParseWhenHtmlBlockArrivesLineByLine() {
+    fun htmlBlockArrivesLineByLine() {
         val text = """
             <div>
             text in html block
@@ -179,7 +179,7 @@ class StreamingMarkdownConsistencyTest {
     }
 
     @Test
-    fun streamingParseMatchesFullParseWhenReferenceDefinitionArrivesAfterReferenceLink() {
+    fun referenceDefinitionArrivesAfterReferenceLink() {
         val text = """
             [JetBrains][jb]
 
@@ -193,7 +193,7 @@ class StreamingMarkdownConsistencyTest {
     }
 
     @Test
-    fun streamingParseMatchesFullParseWhenFormattedParagraphArrivesInSmallChunks() {
+    fun formattedParagraphArrivesInSmallChunks() {
         val text = """
             This paragraph has **strong text**, _emphasis_, `inline code`, [a link](https://example.com),
             and enough words to be split across several chunks without ending the paragraph too early.

--- a/src/commonTest/kotlin/org/intellij/markdown/parser/StreamingMarkdownFileTest.kt
+++ b/src/commonTest/kotlin/org/intellij/markdown/parser/StreamingMarkdownFileTest.kt
@@ -88,6 +88,39 @@ class StreamingMarkdownFileTest {
     }
 
     @Test
+    fun longFormattedParagraphStaysAsSingleUnstableParagraph() {
+        val file = EmptyStreamingMarkdownFile()
+
+        file.append("This is a long paragraph with **strong text**, ")
+        file.append("_emphasis_, `inline code`, and [a link](https://example.com)")
+
+        assertTopLevelTypes(file.stableChildren)
+        assertTopLevelTypes(file.unstableTail, MarkdownElementTypes.PARAGRAPH)
+        assertTrue(file.unstableTail.single().containsNodeOfType(MarkdownElementTypes.STRONG))
+        assertTrue(file.unstableTail.single().containsNodeOfType(MarkdownElementTypes.EMPH))
+        assertTrue(file.unstableTail.single().containsNodeOfType(MarkdownElementTypes.CODE_SPAN))
+        assertTrue(file.unstableTail.single().containsNodeOfType(MarkdownElementTypes.INLINE_LINK))
+        assertChildrenAreStablePrefixPlusUnstableTail(file)
+    }
+
+    @Test
+    fun longFormattedParagraphIsPromotedAfterBlankLine() {
+        val file = EmptyStreamingMarkdownFile()
+
+        file.append("This is a long paragraph with **strong text**, ")
+        file.append("_emphasis_, `inline code`, and [a link](https://example.com)")
+        file.append("\n\n")
+
+        val paragraph = file.stableChildren.single { it.type == MarkdownElementTypes.PARAGRAPH }
+        assertTrue(paragraph.containsNodeOfType(MarkdownElementTypes.STRONG))
+        assertTrue(paragraph.containsNodeOfType(MarkdownElementTypes.EMPH))
+        assertTrue(paragraph.containsNodeOfType(MarkdownElementTypes.CODE_SPAN))
+        assertTrue(paragraph.containsNodeOfType(MarkdownElementTypes.INLINE_LINK))
+        assertTrue(file.unstableTail.isEmpty())
+        assertChildrenAreStablePrefixPlusUnstableTail(file)
+    }
+
+    @Test
     fun stablePrefixIsPromotedAfterAppend() {
         val file = EmptyStreamingMarkdownFile()
 
@@ -115,5 +148,9 @@ class StreamingMarkdownFileTest {
 
     private fun assertChildrenAreStablePrefixPlusUnstableTail(file: StreamingMarkdownFile) {
         assertEquals(file.stableChildren + file.unstableTail, file.children)
+    }
+
+    private fun ASTNode.containsNodeOfType(type: IElementType): Boolean {
+        return this.type == type || children.any { it.containsNodeOfType(type) }
     }
 }

--- a/src/commonTest/kotlin/org/intellij/markdown/parser/StreamingMarkdownFileTest.kt
+++ b/src/commonTest/kotlin/org/intellij/markdown/parser/StreamingMarkdownFileTest.kt
@@ -1,0 +1,119 @@
+package org.intellij.markdown.parser
+
+import org.intellij.markdown.IElementType
+import org.intellij.markdown.MarkdownElementTypes
+import org.intellij.markdown.ast.ASTNode
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+class StreamingMarkdownFileTest {
+    @Test
+    fun emptyFileIsMarkdownRoot() {
+        val file = EmptyStreamingMarkdownFile()
+
+        assertEquals(MarkdownElementTypes.MARKDOWN_FILE, file.type)
+        assertEquals(0, file.startOffset)
+        assertEquals(0, file.endOffset)
+        assertNull(file.parent)
+        assertTrue(file.stableChildren.isEmpty())
+        assertTrue(file.unstableTail.isEmpty())
+        assertTrue(file.children.isEmpty())
+    }
+
+    @Test
+    fun appendEmptyChunkDoesNothing() {
+        val file = EmptyStreamingMarkdownFile()
+
+        file.append("")
+
+        assertEquals(0, file.endOffset)
+        assertTrue(file.stableChildren.isEmpty())
+        assertTrue(file.unstableTail.isEmpty())
+        assertTrue(file.children.isEmpty())
+    }
+
+    @Test
+    fun appendUpdatesEndOffset() {
+        val file = EmptyStreamingMarkdownFile()
+
+        file.append("hello")
+
+        assertEquals(5, file.endOffset)
+        assertChildrenAreStablePrefixPlusUnstableTail(file)
+    }
+
+    @Test
+    fun childrenAreStablePrefixPlusUnstableTail() {
+        val file = EmptyStreamingMarkdownFile()
+
+        file.append("hello\n\n")
+        file.append("world")
+
+        assertChildrenAreStablePrefixPlusUnstableTail(file)
+    }
+
+    @Test
+    fun stableChildrenAreNotReplacedByLaterAppend() {
+        val file = EmptyStreamingMarkdownFile()
+
+        file.append("hello\n\n")
+        val stablePrefix = file.stableChildren.toList()
+
+        file.append("world")
+
+        assertTrue(stablePrefix.isNotEmpty())
+        assertTrue(file.stableChildren.size >= stablePrefix.size)
+        stablePrefix.forEachIndexed { index, stableNode ->
+            assertSame(stableNode, file.stableChildren[index])
+        }
+        assertChildrenAreStablePrefixPlusUnstableTail(file)
+    }
+
+    @Test
+    fun unstableTailCanBeReinterpretedByLaterChunk() {
+        val file = EmptyStreamingMarkdownFile()
+
+        file.append("hello")
+
+        assertTopLevelTypes(file.unstableTail, MarkdownElementTypes.PARAGRAPH)
+
+        file.append("\n---")
+
+        assertTopLevelTypes(file.stableChildren)
+        assertTopLevelTypes(file.unstableTail, MarkdownElementTypes.SETEXT_2)
+        assertChildrenAreStablePrefixPlusUnstableTail(file)
+    }
+
+    @Test
+    fun stablePrefixIsPromotedAfterAppend() {
+        val file = EmptyStreamingMarkdownFile()
+
+        file.append("hello\n\n")
+
+        assertEquals(MarkdownElementTypes.PARAGRAPH, file.stableChildren.firstOrNull()?.type)
+        assertTrue(file.unstableTail.isEmpty())
+        assertChildrenAreStablePrefixPlusUnstableTail(file)
+    }
+
+    @Test
+    fun unstableTailOffsetsAreRelativeToFullText() {
+        val file = EmptyStreamingMarkdownFile()
+
+        file.append("hello\n\n")
+        file.append("world")
+
+        assertEquals(7, file.unstableTail.single().startOffset)
+        assertEquals(12, file.unstableTail.single().endOffset)
+    }
+
+    private fun assertTopLevelTypes(nodes: List<ASTNode>, vararg types: IElementType) {
+        assertEquals(types.toList(), nodes.map { it.type })
+    }
+
+    private fun assertChildrenAreStablePrefixPlusUnstableTail(file: StreamingMarkdownFile) {
+        assertEquals(file.stableChildren + file.unstableTail, file.children)
+    }
+}

--- a/src/commonTest/kotlin/org/intellij/markdown/parser/StreamingMarkdownStableOffsetTest.kt
+++ b/src/commonTest/kotlin/org/intellij/markdown/parser/StreamingMarkdownStableOffsetTest.kt
@@ -1,0 +1,101 @@
+package org.intellij.markdown.parser
+
+import org.intellij.markdown.MarkdownElementTypes.MARKDOWN_FILE
+import org.intellij.markdown.flavours.gfm.GFMFlavourDescriptor
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class StreamingMarkdownStableOffsetTest {
+    private val parser = MarkdownParser(GFMFlavourDescriptor())
+
+    @Test
+    fun emptyTextIsStable() {
+        assertUnstableStartOffset("", 0)
+    }
+
+    @Test
+    fun unterminatedParagraphIsUnstableFromLineStart() {
+        assertUnstableStartOffset("hello", 0)
+    }
+
+    @Test
+    fun terminatedParagraphWithBlankLineIsStable() {
+        assertUnstableStartOffset("hello\n\n", 7)
+    }
+
+    @Test
+    fun unterminatedTailAfterStablePrefixIsUnstableFromTailLineStart() {
+        assertUnstableStartOffset("hello\n\nworld", 7)
+    }
+
+    @Test
+    fun unterminatedAtxHeadingIsUnstableFromLineStart() {
+        assertUnstableStartOffset("# title", 0)
+    }
+
+    @Test
+    fun terminatedAtxHeadingStaysUnstableBeforeBlankLine() {
+        assertUnstableStartOffset("# title\n", 0)
+    }
+
+    @Test
+    fun atxHeadingWithBlankLineIsStable() {
+        val text = "# title\n\n"
+
+        assertUnstableStartOffset(text, text.length)
+    }
+
+    @Test
+    fun unterminatedSetextHeadingIsUnstableFromParagraphStart() {
+        assertUnstableStartOffset("hello\n---", 0)
+    }
+
+    @Test
+    fun terminatedSetextHeadingStaysUnstableBeforeBlankLine() {
+        assertUnstableStartOffset("hello\n---\n", 0)
+    }
+
+    @Test
+    fun setextHeadingWithBlankLineIsStable() {
+        val text = "hello\n---\n\n"
+
+        assertUnstableStartOffset(text, text.length)
+    }
+
+    @Test
+    fun unclosedCodeFenceIsUnstableFromFenceStart() {
+        assertUnstableStartOffset("```\ncode\n", 0)
+    }
+
+    @Test
+    fun closedCodeFenceWithUnterminatedClosingLineIsUnstableFromFenceStart() {
+        assertUnstableStartOffset("```\ncode\n```", 0)
+    }
+
+    @Test
+    fun terminatedCodeFenceStaysUnstableBeforeBlankLine() {
+        assertUnstableStartOffset("```\ncode\n```\n", 0)
+    }
+
+    @Test
+    fun codeFenceWithBlankLineIsStable() {
+        val text = "```\ncode\n```\n\n"
+
+        assertUnstableStartOffset(text, text.length)
+    }
+
+    @Test
+    fun baseOffsetIsAppliedToUnstableStartOffset() {
+        assertUnstableStartOffset("hello\n\nworld", 17, baseOffset = 10)
+    }
+
+    private fun assertUnstableStartOffset(
+        text: String,
+        expectedOffset: Int,
+        baseOffset: Int = 0
+    ) {
+        val result = parser.parseStreaming(MARKDOWN_FILE, text, parseInlines = true, baseOffset = baseOffset)
+
+        assertEquals(expectedOffset, result.unstableStartOffset)
+    }
+}


### PR DESCRIPTION
This PR implements a streaming markdown parser that accepts appending content.

Fixes #139 

Every time the markdown is parsed, there will be a stable part of the AST tree. Then we can store it to avoid reparsing this part and only parse the unstable tail.