### PR TITLE
Bump version to 0.7.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # intellij-markdown Changelog
 
 ## [Unreleased]
+
+## [0.7.6]
 - Use `CharSequence` where possible instead of `String`
 - Fixed link-related parser freezes
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=0.7.5
+version=0.7.6
 snapshot=true
 publication_channels=maven-central-snapshot


### PR DESCRIPTION
There are several changes that fix the top 4 most UI freezes in IntelliJ