### PR TITLE
IJPL-92208 Support rendering `>` as literal text inside GFM table cells

### DIFF
--- a/src/commonMain/kotlin/org/intellij/markdown/flavours/gfm/GFMFlavourDescriptor.kt
+++ b/src/commonMain/kotlin/org/intellij/markdown/flavours/gfm/GFMFlavourDescriptor.kt
@@ -64,6 +64,7 @@ open class GFMFlavourDescriptor(
                 GFMElementTypes.TABLE to TablesGeneratingProvider(),
 
                 GFMTokenTypes.CELL to TrimmingInlineHolderProvider(),
+                MarkdownTokenTypes.BLOCK_QUOTE to TableAwareBlockQuoteMarkerProvider(),
                 MarkdownElementTypes.CODE_SPAN to TableAwareCodeSpanGeneratingProvider(),
 
                 GFMTokenTypes.GFM_AUTOLINK to object : GeneratingProvider {

--- a/src/commonMain/kotlin/org/intellij/markdown/flavours/gfm/GFMGeneratingProviders.kt
+++ b/src/commonMain/kotlin/org/intellij/markdown/flavours/gfm/GFMGeneratingProviders.kt
@@ -133,6 +133,22 @@ open class TableAwareCodeSpanGeneratingProvider : GeneratingProvider {
     }
 }
 
+/**
+ * A `>` at the start of a GFM table cell is lexed as a [MarkdownTokenTypes.BLOCK_QUOTE] marker token, but block
+ * quotes are not allowed inside table cells. [HtmlGenerator.leafText] blanks out block-quote marker tokens, so
+ * without special handling the `>` would disappear from the rendered cell. Inside a table cell we render the marker
+ * as literal text; anywhere else we keep the default behaviour of dropping the marker.
+ */
+open class TableAwareBlockQuoteMarkerProvider : GeneratingProvider {
+    override fun processNode(visitor: HtmlGenerator.HtmlGeneratingVisitor, text: String, node: ASTNode) {
+        if (node.getParentOfType(GFMTokenTypes.CELL) == null) {
+            return
+        }
+        val markerText = node.getTextInNode(text).trimStart()
+        visitor.consumeHtml(EntityConverter.replaceEntities(markerText, processEntities = false, processEscapes = false))
+    }
+}
+
 internal class MathGeneratingProvider(private val inline: Boolean = false): GeneratingProvider {
     override fun processNode(visitor: HtmlGenerator.HtmlGeneratingVisitor, text: String, node: ASTNode) {
         val nodes = node.children.subList(1, node.children.size - 1)

--- a/src/fileBasedTest/kotlin/org/intellij/markdown/HtmlGeneratorCommonTest.kt
+++ b/src/fileBasedTest/kotlin/org/intellij/markdown/HtmlGeneratorCommonTest.kt
@@ -4,8 +4,11 @@ import org.intellij.markdown.ast.ASTNode
 import org.intellij.markdown.flavours.commonmark.CommonMarkFlavourDescriptor
 import org.intellij.markdown.flavours.gfm.GFMFlavourDescriptor
 import org.intellij.markdown.flavours.space.SFMFlavourDescriptor
-import org.intellij.markdown.html.*
-import kotlin.test.*
+import org.intellij.markdown.html.HtmlGenerator
+import org.intellij.markdown.html.URI
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.fail
 
 class HtmlGeneratorCommonTest : HtmlGeneratorTestBase() {
     override fun getTestDataPath(): String {
@@ -129,6 +132,11 @@ class HtmlGeneratorCommonTest : HtmlGeneratorTestBase() {
 
     @Test
     fun testGfmTable() {
+        defaultTest(GFMFlavourDescriptor())
+    }
+
+    @Test
+    fun testGfmTableWithBlockQuote() {
         defaultTest(GFMFlavourDescriptor())
     }
 

--- a/src/fileBasedTest/kotlin/org/intellij/markdown/MarkdownParsingTest.kt
+++ b/src/fileBasedTest/kotlin/org/intellij/markdown/MarkdownParsingTest.kt
@@ -246,6 +246,11 @@ class MarkdownParsingTest : TestCase() {
     }
 
     @Test
+    fun testGfmTableWithBlockQuote() {
+        defaultTest(GFMFlavourDescriptor())
+    }
+
+    @Test
     fun testGfmAlerts() {
         defaultTest(GFMFlavourDescriptor())
     }

--- a/src/fileBasedTest/resources/data/html/gfmTableWithBlockQuote.md
+++ b/src/fileBasedTest/resources/data/html/gfmTableWithBlockQuote.md
@@ -1,0 +1,8 @@
+Table cells hold inline content only, so a leading `>` is literal text rather than a block quote.
+
+| Name | Version |
+|------|---------|
+| terraform | >= 1.3.0 |
+| answer | >0 |
+
+> A real block quote is still rendered as a quote.

--- a/src/fileBasedTest/resources/data/html/gfmTableWithBlockQuote.txt
+++ b/src/fileBasedTest/resources/data/html/gfmTableWithBlockQuote.txt
@@ -1,0 +1,26 @@
+<body>
+<p>
+Table cells hold inline content only, so a leading <code>&gt;</code>
+ is literal text rather than a block quote.</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Version</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>terraform</td>
+<td>&gt;= 1.3.0</td>
+</tr>
+<tr class="intellij-row-even">
+<td>answer</td>
+<td>&gt;0</td>
+</tr>
+</tbody>
+</table>
+<blockquote>
+<p>A real block quote is still rendered as a quote.</p>
+</blockquote>
+</body>

--- a/src/fileBasedTest/resources/data/parser/gfmTableWithBlockQuote.md
+++ b/src/fileBasedTest/resources/data/parser/gfmTableWithBlockQuote.md
@@ -1,0 +1,8 @@
+Table cells hold inline content only, so a leading `>` is literal text rather than a block quote.
+
+| Name | Version |
+|------|---------|
+| terraform | >= 1.3.0 |
+| answer | >0 |
+
+> A real block quote is still rendered as a quote.

--- a/src/fileBasedTest/resources/data/parser/gfmTableWithBlockQuote.txt
+++ b/src/fileBasedTest/resources/data/parser/gfmTableWithBlockQuote.txt
@@ -1,0 +1,64 @@
+Markdown:MARKDOWN_FILE
+  Markdown:PARAGRAPH
+    Markdown:TEXT('Table cells hold inline content only,')
+    WHITE_SPACE(' ')
+    Markdown:TEXT('so a leading')
+    WHITE_SPACE(' ')
+    Markdown:CODE_SPAN
+      Markdown:BACKTICK('`')
+      Markdown:>('>')
+      Markdown:BACKTICK('`')
+    WHITE_SPACE(' ')
+    Markdown:TEXT('is literal text rather than a block quote.')
+  Markdown:EOL('\n')
+  Markdown:EOL('\n')
+  Markdown:TABLE
+    Markdown:HEADER
+      Markdown:TABLE_SEPARATOR('|')
+      Markdown:CELL
+        WHITE_SPACE(' ')
+        Markdown:TEXT('Name')
+        WHITE_SPACE(' ')
+      Markdown:TABLE_SEPARATOR('|')
+      Markdown:CELL
+        WHITE_SPACE(' ')
+        Markdown:TEXT('Version')
+        WHITE_SPACE(' ')
+      Markdown:TABLE_SEPARATOR('|')
+    Markdown:EOL('\n')
+    Markdown:TABLE_SEPARATOR('|------|---------|')
+    Markdown:EOL('\n')
+    Markdown:ROW
+      Markdown:TABLE_SEPARATOR('|')
+      Markdown:CELL
+        WHITE_SPACE(' ')
+        Markdown:TEXT('terraform')
+        WHITE_SPACE(' ')
+      Markdown:TABLE_SEPARATOR('|')
+      Markdown:CELL
+        Markdown:BLOCK_QUOTE(' >')
+        Markdown:TEXT('=')
+        WHITE_SPACE(' ')
+        Markdown:TEXT('1.3.0')
+        WHITE_SPACE(' ')
+      Markdown:TABLE_SEPARATOR('|')
+    Markdown:EOL('\n')
+    Markdown:ROW
+      Markdown:TABLE_SEPARATOR('|')
+      Markdown:CELL
+        WHITE_SPACE(' ')
+        Markdown:TEXT('answer')
+        WHITE_SPACE(' ')
+      Markdown:TABLE_SEPARATOR('|')
+      Markdown:CELL
+        Markdown:BLOCK_QUOTE(' >')
+        Markdown:TEXT('0')
+        WHITE_SPACE(' ')
+      Markdown:TABLE_SEPARATOR('|')
+  Markdown:EOL('\n')
+  Markdown:EOL('\n')
+  Markdown:BLOCK_QUOTE
+    Markdown:BLOCK_QUOTE('> ')
+    Markdown:PARAGRAPH
+      Markdown:TEXT('A real block quote is still rendered as a quote.')
+  Markdown:EOL('\n')


### PR DESCRIPTION
[IJPL-92208](https://youtrack.jetbrains.com/issue/IJPL-92208) Greater than > not correctly rendered by IntelliJ bundled markdown plugin