### PR TITLE
[GFM] Implement the tagfilter extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # intellij-markdown Changelog
 
 ## [Unreleased]
+- [#211] Add support for the GFM tagfilter extension
 
 ## [0.7.9]
 - [#210] Accept a `CancellationToken` in `EmptyStreamingMarkdownFile`

--- a/src/commonMain/kotlin/org/intellij/markdown/flavours/gfm/GFMFlavourDescriptor.kt
+++ b/src/commonMain/kotlin/org/intellij/markdown/flavours/gfm/GFMFlavourDescriptor.kt
@@ -55,6 +55,9 @@ open class GFMFlavourDescriptor(
     override fun createHtmlGeneratingProviders(linkMap: LinkMap,
                                                baseURI: URI?): Map<IElementType, GeneratingProvider> {
         return super.createHtmlGeneratingProviders(linkMap, baseURI) + hashMapOf(
+                MarkdownElementTypes.HTML_BLOCK to GFMHtmlBlockGeneratingProvider,
+                MarkdownTokenTypes.HTML_TAG to GFMInlineHtmlGeneratingProvider,
+
                 GFMElementTypes.STRIKETHROUGH to object : EqualDelimiterTrimmingInlineTagProvider("span", GFMTokenTypes.TILDE) {
                     override fun openTag(visitor: HtmlGenerator.HtmlGeneratingVisitor, text: String, node: ASTNode) {
                         visitor.consumeTagOpen(node, tagName, "class=\"user-del\"")

--- a/src/commonMain/kotlin/org/intellij/markdown/flavours/gfm/GFMGeneratingProviders.kt
+++ b/src/commonMain/kotlin/org/intellij/markdown/flavours/gfm/GFMGeneratingProviders.kt
@@ -1,6 +1,7 @@
 package org.intellij.markdown.flavours.gfm
 
 import org.intellij.markdown.MarkdownElementTypes
+import org.intellij.markdown.MarkdownTokenTypes
 import org.intellij.markdown.ast.*
 import org.intellij.markdown.ast.impl.ListCompositeNode
 import org.intellij.markdown.ast.impl.ListItemCompositeNode
@@ -10,6 +11,31 @@ import org.intellij.markdown.html.InlineHolderGeneratingProvider
 import org.intellij.markdown.html.SimpleTagProvider
 import org.intellij.markdown.html.entities.EntityConverter
 import org.intellij.markdown.lexer.Compat.assert
+
+private val DISALLOWED_RAW_HTML_TAG = Regex(
+    "</?(?:title|textarea|style|xmp|iframe|noembed|noframes|script|plaintext)(?=\\s|/?>|$)",
+    RegexOption.IGNORE_CASE
+)
+
+internal fun filterDisallowedRawHtml(html: CharSequence): CharSequence =
+    DISALLOWED_RAW_HTML_TAG.replace(html) { "&lt;${it.value.substring(1)}" }
+
+internal object GFMInlineHtmlGeneratingProvider : GeneratingProvider {
+    override fun processNode(visitor: HtmlGenerator.HtmlGeneratingVisitor, text: String, node: ASTNode) {
+        visitor.consumeHtml(filterDisallowedRawHtml(node.getTextInNode(text)))
+    }
+}
+
+internal object GFMHtmlBlockGeneratingProvider : GeneratingProvider {
+    override fun processNode(visitor: HtmlGenerator.HtmlGeneratingVisitor, text: String, node: ASTNode) {
+        for (child in node.children) {
+            if (child.type in listOf(MarkdownTokenTypes.EOL, MarkdownTokenTypes.HTML_BLOCK_CONTENT)) {
+                visitor.consumeHtml(filterDisallowedRawHtml(child.getTextInNode(text)))
+            }
+        }
+        visitor.consumeHtml("\n")
+    }
+}
 
 internal class CheckedListItemGeneratingProvider : SimpleTagProvider("li") {
     override fun openTag(visitor: HtmlGenerator.HtmlGeneratingVisitor, text: String, node: ASTNode) {

--- a/src/commonMain/kotlin/org/intellij/markdown/parser/markerblocks/providers/HtmlBlockProvider.kt
+++ b/src/commonMain/kotlin/org/intellij/markdown/parser/markerblocks/providers/HtmlBlockProvider.kt
@@ -80,7 +80,7 @@ class HtmlBlockProvider : MarkerBlockProvider<MarkerProcessor.StateInfo> {
                 Pair(Regex("<![A-Z]"), Regex(">")),
                 Pair(Regex("<!\\[CDATA\\["), Regex("\\]\\]>")),
                 Pair(Regex("</?(?:${TAG_NAMES.replace(", ", "|")})(?: |/?>|$)", RegexOption.IGNORE_CASE), null),
-                Pair(Regex("(?:${OPEN_TAG}|${CLOSE_TAG})(?: |$)"), null)
+                Pair(Regex("(?:${OPEN_TAG}|${CLOSE_TAG})\\s*$"), null)
         )
 
         val FIND_START_REGEX = Regex(

--- a/src/commonTest/kotlin/org/intellij/markdown/GfmSpecTest.kt
+++ b/src/commonTest/kotlin/org/intellij/markdown/GfmSpecTest.kt
@@ -858,19 +858,19 @@ class GfmSpecTest : SpecTest(org.intellij.markdown.flavours.gfm.GFMFlavourDescri
     @Test
     fun testHTMLBlocksExample140() = doTest(
             markdown = "<script type=\"text/javascript\">\n// JavaScript example\n\ndocument.getElementById(\"demo\").innerHTML = \"Hello JavaScript!\";\n</script>\nokay\n",
-            html = "<script type=\"text/javascript\">\n// JavaScript example\n\ndocument.getElementById(\"demo\").innerHTML = \"Hello JavaScript!\";\n</script>\n<p>okay</p>\n"
+            html = "&lt;script type=\"text/javascript\">\n// JavaScript example\n\ndocument.getElementById(\"demo\").innerHTML = \"Hello JavaScript!\";\n&lt;/script>\n<p>okay</p>\n"
     )
 
     @Test
     fun testHTMLBlocksExample141() = doTest(
             markdown = "<style\n  type=\"text/css\">\nh1 {color:red;}\n\np {color:blue;}\n</style>\nokay\n",
-            html = "<style\n  type=\"text/css\">\nh1 {color:red;}\n\np {color:blue;}\n</style>\n<p>okay</p>\n"
+            html = "&lt;style\n  type=\"text/css\">\nh1 {color:red;}\n\np {color:blue;}\n&lt;/style>\n<p>okay</p>\n"
     )
 
     @Test
     fun testHTMLBlocksExample142() = doTest(
             markdown = "<style\n  type=\"text/css\">\n\nfoo\n",
-            html = "<style\n  type=\"text/css\">\n\nfoo\n"
+            html = "&lt;style\n  type=\"text/css\">\n\nfoo\n"
     )
 
     @Test
@@ -888,7 +888,7 @@ class GfmSpecTest : SpecTest(org.intellij.markdown.flavours.gfm.GFMFlavourDescri
     @Test
     fun testHTMLBlocksExample145() = doTest(
             markdown = "<style>p{color:red;}</style>\n*foo*\n",
-            html = "<style>p{color:red;}</style>\n<p><em>foo</em></p>\n"
+            html = "&lt;style>p{color:red;}&lt;/style>\n<p><em>foo</em></p>\n"
     )
 
     @Test
@@ -900,7 +900,7 @@ class GfmSpecTest : SpecTest(org.intellij.markdown.flavours.gfm.GFMFlavourDescri
     @Test
     fun testHTMLBlocksExample147() = doTest(
             markdown = "<script>\nfoo\n</script>1. *bar*\n",
-            html = "<script>\nfoo\n</script>1. *bar*\n"
+            html = "&lt;script>\nfoo\n&lt;/script>1. *bar*\n"
     )
 
     @Test
@@ -4034,7 +4034,6 @@ class GfmSpecTest : SpecTest(org.intellij.markdown.flavours.gfm.GFMFlavourDescri
     )
 
     @Test
-    @Ignore
     fun testDisallowedRawHTMLExample653() = doTest(
             markdown = "<strong> <title> <style> <em>\n\n<blockquote>\n  <xmp> is disallowed.  <XMP> is also disallowed.\n</blockquote>\n",
             html = "<p><strong> &lt;title> &lt;style> <em></p>\n<blockquote>\n  &lt;xmp> is disallowed.  &lt;XMP> is also disallowed.\n</blockquote>\n"

--- a/src/commonTest/kotlin/org/intellij/markdown/GfmTest.kt
+++ b/src/commonTest/kotlin/org/intellij/markdown/GfmTest.kt
@@ -1,5 +1,6 @@
 package org.intellij.markdown
 
+import org.intellij.markdown.flavours.commonmark.CommonMarkFlavourDescriptor
 import kotlin.test.Test
 
 class GfmTest: SpecTest(org.intellij.markdown.flavours.gfm.GFMFlavourDescriptor()) {
@@ -8,4 +9,36 @@ class GfmTest: SpecTest(org.intellij.markdown.flavours.gfm.GFMFlavourDescriptor(
         markdown = "<a href=\"https://jb.gg\">https://www.jb.gg/?q=19</a>",
         html = "<p><a href=\"https://jb.gg\"><a href=\"https://www.jb.gg/?q=19\">https://www.jb.gg/?q=19</a></a></p>"
     )
+
+    @Test
+    fun testDisallowedRawHtmlTagsAreFiltered() = doTest(
+        markdown = "before <title> <TEXTAREA rows=\"2\"> </style> <xmp> <iframe> <noembed> <noframes> <script> <plaintext> after",
+        html = "<p>before &lt;title> &lt;TEXTAREA rows=\"2\"> &lt;/style> &lt;xmp> &lt;iframe> &lt;noembed> &lt;noframes> &lt;script> &lt;plaintext> after</p>"
+    )
+
+    @Test
+    fun testDisallowedRawHtmlTagsAreFilteredInHtmlBlocks() = doTest(
+        markdown = "<script>\nalert('test');\n</script>\n",
+        html = "&lt;script>\nalert('test');\n&lt;/script>\n"
+    )
+
+    @Test
+    fun testOtherRawHtmlTagsAndSimilarNamesAreNotFiltered() = doTest(
+        markdown = "before <strong> <scripture> </scripted> after",
+        html = "<p>before <strong> <scripture> </scripted> after</p>"
+    )
+
+    @Test
+    fun testSelfClosingDisallowedRawHtmlTagsAreFiltered() = doTest(
+        markdown = "before <script/> <IFRAME/> after",
+        html = "<p>before &lt;script/> &lt;IFRAME/> after</p>"
+    )
+
+    @Test
+    fun testCommonMarkRawHtmlIsNotFiltered() {
+        object : SpecTest(CommonMarkFlavourDescriptor()) {}.doTest(
+            markdown = "before <title> <script> after",
+            html = "<p>before <title> <script> after</p>"
+        )
+    }
 }


### PR DESCRIPTION
## Summary

Implement the GFM `tagfilter` extension for raw HTML rendering.

The extension replaces the leading `<` with `&lt;` for the following tags, matched case-insensitively:

- `title`
- `textarea`
- `style`
- `xmp`
- `iframe`
- `noembed`
- `noframes`
- `script`
- `plaintext`

Both inline HTML and HTML blocks are covered. Other HTML tags and CommonMark rendering remain unchanged.

This also tightens the type 7 HTML block start condition: after a complete opening or closing tag, only whitespace may appear before the end of the line. The previous condition incorrectly classified lines such as `<strong> <title>` as HTML blocks.

Closes #211

## Tests

Added coverage for:

- the official GFM tagfilter example
- inline and block HTML
- opening, closing, and self-closing tags
- attributes and case-insensitive matching
- allowed HTML tags
- similar tag names such as `<scripture>`
- unchanged CommonMark behavior

Existing GFM HTML block expectations were updated because `GFMFlavourDescriptor` enables GFM extensions globally.

## Verification

- `./gradlew jvmTest`
- `./gradlew jsNodeTest`

Closes #ISSUE_NUMBER