### PR TITLE
Add GitLab Flavored Markdown (GLFM) flavour

### DIFF
--- a/src/commonMain/kotlin/org/intellij/markdown/flavours/glfm/EmojiParser.kt
+++ b/src/commonMain/kotlin/org/intellij/markdown/flavours/glfm/EmojiParser.kt
@@ -1,0 +1,82 @@
+package org.intellij.markdown.flavours.glfm
+
+import org.intellij.markdown.MarkdownTokenTypes
+import org.intellij.markdown.parser.sequentialparsers.RangesListBuilder
+import org.intellij.markdown.parser.sequentialparsers.SequentialParser
+import org.intellij.markdown.parser.sequentialparsers.TokensCache
+
+/**
+ * Parser for GitLab emoji shortcodes.
+ *
+ * Recognizes emoji in the format `:emoji_name:` where emoji_name consists of
+ * alphanumeric characters, underscores, hyphens, and plus signs.
+ * The name must not contain whitespace and the two colons must be adjacent
+ * to the name (`: smile :` is NOT an emoji).
+ *
+ * Examples: `:smile:`, `:thumbsup:`, `:+1:`
+ */
+class EmojiParser : SequentialParser {
+    override fun parse(tokens: TokensCache, rangesToGlue: List<IntRange>): SequentialParser.ParsingResult {
+        val result = SequentialParser.ParsingResultBuilder()
+        val delegateIndices = RangesListBuilder()
+        var iterator: TokensCache.Iterator = tokens.RangesListIterator(rangesToGlue)
+
+        while (iterator.type != null) {
+            if (iterator.type == MarkdownTokenTypes.COLON) {
+                val match = matchEmoji(tokens, iterator)
+                if (match != null) {
+                    result.withNode(
+                        SequentialParser.Node(
+                            iterator.index..match.index + 1,
+                            GLFMElementTypes.EMOJI
+                        )
+                    )
+                    iterator = match.advance()
+                    continue
+                }
+            }
+            delegateIndices.put(iterator.index)
+            iterator = iterator.advance()
+        }
+
+        return result.withFurtherProcessing(delegateIndices.get())
+    }
+
+    /**
+     * Attempts to match `:name:` starting at the opening COLON [it].
+     * Returns the iterator positioned at the closing COLON, or null.
+     */
+    private fun matchEmoji(tokens: TokensCache, it: TokensCache.Iterator): TokensCache.Iterator? {
+        var current = it.advance()
+        var nameLength = 0
+        var prevEnd = it.end
+
+        while (current.type != null && current.type != MarkdownTokenTypes.COLON) {
+            // Tokens must be adjacent — a gap means whitespace was filtered out,
+            // which is not allowed inside an emoji name.
+            if (current.start != prevEnd) return null
+
+            // Every char of the token must be a valid emoji-name char
+            for (offset in current.start until current.end) {
+                if (!isValidEmojiChar(tokens.getRawCharAt(offset))) return null
+            }
+
+            nameLength += current.length
+            if (nameLength > 50) return null
+
+            prevEnd = current.end
+            current = current.advance()
+        }
+
+        if (current.type != MarkdownTokenTypes.COLON) return null
+        // Closing colon must also be adjacent to the name
+        if (current.start != prevEnd) return null
+        if (nameLength == 0) return null
+
+        return current
+    }
+
+    private fun isValidEmojiChar(char: Char): Boolean {
+        return char.isLetterOrDigit() || char == '_' || char == '-' || char == '+'
+    }
+}

--- a/src/commonMain/kotlin/org/intellij/markdown/flavours/glfm/GLFMElementTypes.kt
+++ b/src/commonMain/kotlin/org/intellij/markdown/flavours/glfm/GLFMElementTypes.kt
@@ -1,0 +1,37 @@
+package org.intellij.markdown.flavours.glfm
+
+import org.intellij.markdown.IElementType
+import org.intellij.markdown.MarkdownElementType
+import kotlin.jvm.JvmField
+
+/**
+ * GitLab Flavored Markdown specific element types.
+ *
+ * The design mirrors [org.intellij.markdown.flavours.gfm.GFMElementTypes]
+ * to keep integration simple.
+ */
+object GLFMElementTypes {
+    /** `>>> … >>>` multiline blockquote block. */
+    @JvmField
+    val MULTILINE_BLOCK_QUOTE: IElementType = MarkdownElementType("MULTILINE_BLOCK_QUOTE")
+
+    /** `{+ added text +}` inline diff addition. */
+    @JvmField
+    val INLINE_DIFF_ADDITION: IElementType = MarkdownElementType("INLINE_DIFF_ADDITION")
+
+    /** `[- deleted text -]` inline diff deletion. */
+    @JvmField
+    val INLINE_DIFF_DELETION: IElementType = MarkdownElementType("INLINE_DIFF_DELETION")
+
+    /** GitLab references: `@user`, `#issue`, `!mr`, `$snippet`, `&epic`, `~label`, `%milestone`. */
+    @JvmField
+    val GITLAB_REFERENCE: IElementType = MarkdownElementType("GITLAB_REFERENCE")
+
+    /** `:emoji_name:` shortcode. */
+    @JvmField
+    val EMOJI: IElementType = MarkdownElementType("EMOJI")
+
+    // Alert blocks ( > [!note], etc. ) are represented as blockquotes in the
+    // block parser and recognized during HTML generation, so no dedicated
+    // element types are needed.
+}

--- a/src/commonMain/kotlin/org/intellij/markdown/flavours/glfm/GLFMFlavourDescriptor.kt
+++ b/src/commonMain/kotlin/org/intellij/markdown/flavours/glfm/GLFMFlavourDescriptor.kt
@@ -1,0 +1,312 @@
+package org.intellij.markdown.flavours.glfm
+
+import org.intellij.markdown.IElementType
+import org.intellij.markdown.MarkdownElementTypes
+import org.intellij.markdown.MarkdownTokenTypes
+import org.intellij.markdown.ast.ASTNode
+import org.intellij.markdown.ast.acceptChildren
+import org.intellij.markdown.ast.getTextInNode
+import org.intellij.markdown.flavours.gfm.GFMFlavourDescriptor
+import org.intellij.markdown.flavours.gfm.GFMTokenTypes
+import org.intellij.markdown.flavours.gfm.StrikeThroughDelimiterParser
+import org.intellij.markdown.parser.MarkerProcessorFactory
+import org.intellij.markdown.html.GeneratingProvider
+import org.intellij.markdown.html.HtmlGenerator
+import org.intellij.markdown.html.URI
+import org.intellij.markdown.parser.LinkMap
+import org.intellij.markdown.parser.sequentialparsers.EmphasisLikeParser
+import org.intellij.markdown.parser.sequentialparsers.SequentialParser
+import org.intellij.markdown.parser.sequentialparsers.SequentialParserManager
+import org.intellij.markdown.parser.sequentialparsers.impl.*
+
+/**
+ * GitLab Flavored Markdown flavour.
+ *
+ * This flavour extends the GitHub Flavored Markdown implementation and
+ * incrementally adds GitLab-specific behaviour. The goal is to stay close to
+ * GitLab's own GLFM spec while reusing as much of the existing GFM
+ * infrastructure as possible.
+ */
+open class GLFMFlavourDescriptor(
+    useSafeLinks: Boolean = true,
+    absolutizeAnchorLinks: Boolean = false,
+    makeHttpsAutoLinks: Boolean = false,
+    val gitlabBaseUrl: String = "",
+    val gitlabProject: String = "",
+    val emojiMap: Map<String, String> = EmojiGeneratingProvider.DEFAULT_EMOJI_MAP
+) : GFMFlavourDescriptor(useSafeLinks, absolutizeAnchorLinks, makeHttpsAutoLinks) {
+
+    override val markerProcessorFactory: MarkerProcessorFactory = GLFMMarkerProcessor.Factory
+
+    override val sequentialParserManager = object : SequentialParserManager() {
+        override fun getParserSequence(): List<SequentialParser> {
+            return listOf(
+                AutolinkParser(listOf(MarkdownTokenTypes.AUTOLINK, GFMTokenTypes.GFM_AUTOLINK)),
+                BacktickParser(),
+                MathParser(),
+                // Emoji and references run first so they are recognized even
+                // inside inline diff spans (InlineDiffParser consumes its inner
+                // tokens from further processing).
+                EmojiParser(),
+                GitLabReferenceParser(),
+                // InlineDiffParser must run before link parsers so [- deletion -]
+                // is not consumed as a reference link bracket pair.
+                InlineDiffParser(),
+                ImageParser(),
+                InlineLinkParser(),
+                ReferenceLinkParser(),
+                // Keep emphasis last as it's the most complex
+                EmphasisLikeParser(EmphStrongDelimiterParser(), StrikeThroughDelimiterParser())
+            )
+        }
+    }
+
+    override fun createHtmlGeneratingProviders(
+        linkMap: LinkMap,
+        baseURI: URI?,
+    ): Map<IElementType, GeneratingProvider> {
+        // Start from the GFM providers and add/override GLFM-specific ones.
+        val baseProviders = super.createHtmlGeneratingProviders(linkMap, baseURI)
+
+        val glfmProviders = hashMapOf<IElementType, GeneratingProvider>(
+            // Multiline blockquote (>>> fence)
+            GLFMElementTypes.MULTILINE_BLOCK_QUOTE to MultilineBlockQuoteGeneratingProvider(),
+
+            // Inline diff additions and deletions
+            GLFMElementTypes.INLINE_DIFF_ADDITION to InlineDiffGeneratingProvider(),
+            GLFMElementTypes.INLINE_DIFF_DELETION to InlineDiffGeneratingProvider(),
+
+            // Emoji shortcodes
+            GLFMElementTypes.EMOJI to EmojiGeneratingProvider(emojiMap),
+
+            // GitLab references (@user, #issue, !MR, etc.)
+            GLFMElementTypes.GITLAB_REFERENCE to GitLabReferenceGeneratingProvider(
+                gitlabBaseUrl,
+                gitlabProject
+            ),
+
+            // Alerts are GitLab-specific blockquotes that start with an
+            // "alert marker" like `[!note]`. We render them as a dedicated
+            // alert container instead of a plain `<blockquote>`.
+            MarkdownElementTypes.BLOCK_QUOTE to AlertOrBlockQuoteGeneratingProvider(
+                baseProviders[MarkdownElementTypes.BLOCK_QUOTE]
+            ),
+        )
+
+        return baseProviders + glfmProviders
+    }
+
+    /**
+     * Renders blockquotes, upgrading them to GLFM alerts when the first
+     * non-whitespace content starts with an alert marker like `[!note]`.
+     */
+    internal class AlertOrBlockQuoteGeneratingProvider(
+        private val delegate: GeneratingProvider?,
+    ) : GeneratingProvider {
+
+        override fun processNode(
+            visitor: HtmlGenerator.HtmlGeneratingVisitor,
+            text: String,
+            node: ASTNode,
+        ) {
+            // Detect GitLab multiline blockquote (`>>>` fence).
+            // The block parser produces triple-nested BLOCK_QUOTE for `>>>`.
+            // We unwrap it into a single <blockquote> and skip the fence lines.
+            val mlContent = extractMultilineContent(node)
+            if (mlContent != null) {
+                visitor.consumeTagOpen(node, "blockquote")
+                mlContent.forEach { visitor.visitNode(it) }
+                visitor.consumeTagClose("blockquote")
+                return
+            }
+
+            val alertInfo = detectAlert(node, text)
+            if (alertInfo == null) {
+                // Fallback to the original blockquote behaviour.
+                delegate?.processNode(visitor, text, node)
+                    ?: node.acceptChildren(visitor)
+                return
+            }
+
+            val (kind, title) = alertInfo
+
+            // Render alert wrapper. We keep the structure simple and leave
+            // styling to the consumer.
+            val alertClass = "gl-alert gl-alert-$kind"
+            visitor.consumeTagOpen(node, "div", "class=\"$alertClass\"")
+
+            visitor.consumeTagOpen(node, "div", "class=\"gl-alert-title\"")
+            visitor.consumeHtml(title)
+            visitor.consumeTagClose("div")
+
+            visitor.consumeTagOpen(node, "div", "class=\"gl-alert-body\"")
+            // Render original blockquote content, but with the alert marker
+            // stripped from the first text leaf.
+            renderBodyWithoutMarker(visitor, text, node)
+            visitor.consumeTagClose("div")
+
+            visitor.consumeTagClose("div")
+        }
+
+        /**
+         * Returns the content nodes to render if [node] is the outer blockquote
+         * of a GitLab `>>>` multiline blockquote, or null otherwise.
+         *
+         * The block parser produces this AST for `>>>\ncontent\n>>>`:
+         *   BLOCK_QUOTE (outer, from first `>`)
+         *     BLOCK_QUOTE BLOCK_QUOTE [empty]   ← opening fence `>>>`
+         *     PARAGRAPH ...                      ← content
+         *     BLOCK_QUOTE BLOCK_QUOTE [empty]   ← closing fence `>>>`
+         */
+        private fun isMultilineBlockQuote(node: ASTNode, text: String): Boolean =
+            extractMultilineContent(node) != null
+
+        private fun extractMultilineContent(node: ASTNode): List<ASTNode>? {
+            val children = node.children.filter {
+                it.type != MarkdownTokenTypes.EOL &&
+                it.type != MarkdownTokenTypes.WHITE_SPACE &&
+                it.type != MarkdownTokenTypes.BLOCK_QUOTE
+            }
+            val bqChildren = node.children.filter { it.type == MarkdownElementTypes.BLOCK_QUOTE }
+
+            // Pattern: at least 2 BQ children (opening + closing fence) and some content
+            if (bqChildren.size < 2) return null
+
+            // Opening fence: first BQ child must be a double-nested empty BQ
+            if (!isEmptyDoubleBQ(bqChildren.first())) return null
+            // Closing fence: last BQ child must be a double-nested empty BQ
+            if (!isEmptyDoubleBQ(bqChildren.last())) return null
+
+            // Content: all children between the first and last BQ fence
+            val firstFenceEnd = node.children.indexOf(bqChildren.first())
+            val lastFenceStart = node.children.lastIndexOf(bqChildren.last())
+            if (firstFenceEnd < 0 || lastFenceStart <= firstFenceEnd) return null
+
+            return node.children.subList(firstFenceEnd + 1, lastFenceStart).filter {
+                it.type != MarkdownTokenTypes.EOL
+            }
+        }
+
+        /** True if [node] is `BLOCK_QUOTE → BLOCK_QUOTE → (empty)`. */
+        private fun isEmptyDoubleBQ(node: ASTNode): Boolean {
+            if (node.type != MarkdownElementTypes.BLOCK_QUOTE) return false
+            val innerBQs = node.children.filter { it.type == MarkdownElementTypes.BLOCK_QUOTE }
+            if (innerBQs.size != 1) return false
+            val innermost = innerBQs.first()
+            val innermostContent = innermost.children.filter {
+                it.type != MarkdownTokenTypes.EOL && it.type != MarkdownTokenTypes.WHITE_SPACE &&
+                it.type != MarkdownTokenTypes.BLOCK_QUOTE
+            }
+            return innermostContent.isEmpty()
+        }
+
+        private fun detectAlert(node: ASTNode, text: String): Pair<String, String>? {
+            // Collect all leaves in document order and join their text to
+            // reconstruct the inline content.  The alert marker `[!note]` is
+            // tokenized as four separate leaves: `[`, `!`, `note`, `]`.
+            val leaves = node.children.flatMap { collectLeaves(it) }
+            val joined = leaves.joinToString("") { it.getTextInNode(text) }.trimStart()
+
+            // Strip block-quote `>` markers and whitespace that appear at the
+            // start (they are included as BLOCK_QUOTE token leaves).
+            val stripped = joined.trimStart('>', ' ', '\t')
+
+            if (!stripped.startsWith("[!")) return null
+
+            val closing = stripped.indexOf(']')
+            if (closing <= 2) return null
+
+            val marker = stripped.substring(0, closing + 1)
+            val kind = when (marker.lowercase()) {
+                "[!note]" -> "note"
+                "[!tip]" -> "tip"
+                "[!important]" -> "important"
+                "[!caution]" -> "caution"
+                "[!warning]" -> "warning"
+                else -> return null
+            }
+
+            val title = kind.replaceFirstChar { it.uppercaseChar() }
+            return kind to title
+        }
+
+        private fun renderBodyWithoutMarker(
+            visitor: HtmlGenerator.HtmlGeneratingVisitor,
+            text: String,
+            node: ASTNode,
+        ) {
+            // Find the marker node (SHORT_REFERENCE_LINK or bare token group for `[!kind]`)
+            // by its offset range so we can skip it during rendering.
+            val markerRange = findMarkerOffsetRange(node, text)
+
+            fun renderNode(n: ASTNode) {
+                // Suppress any node that is entirely within the marker range
+                if (markerRange != null &&
+                    n.startOffset >= markerRange.first &&
+                    n.endOffset <= markerRange.last
+                ) return
+
+                if (n.children.isEmpty()) {
+                    visitor.visitLeaf(n)
+                } else {
+                    visitor.visitNode(n)
+                }
+            }
+
+            // Walk blockquote children — for PARAGRAPH nodes recurse to allow
+            // per-child suppression
+            fun renderContainer(container: ASTNode) {
+                for (child in container.children) {
+                    if (child.type == MarkdownElementTypes.PARAGRAPH) {
+                        visitor.consumeTagOpen(child, "p")
+                        child.children.forEach { renderNode(it) }
+                        visitor.consumeTagClose("p")
+                    } else {
+                        renderNode(child)
+                    }
+                }
+            }
+
+            renderContainer(node)
+        }
+
+        /**
+         * Returns the char-offset range covering the `[!kind]` marker in
+         * the first content line of this blockquote node, or null if not found.
+         */
+        private fun findMarkerOffsetRange(node: ASTNode, text: String): IntRange? {
+            // The marker may be parsed as SHORT_REFERENCE_LINK([!note]) or as
+            // bare tokens `[` `!` `TEXT` `]`. Either way, we find the leftmost
+            // `[!` sequence in the first non-empty, non-blockquote leaf cluster.
+            val leaves = node.children.flatMap { collectLeaves(it) }
+            var idx = 0
+            while (idx < leaves.size) {
+                val t = leaves[idx].getTextInNode(text).toString()
+                if (t.trimStart(' ', '\t') == ">" || t.isBlank() ||
+                    leaves[idx].type == MarkdownTokenTypes.BLOCK_QUOTE) {
+                    idx++; continue
+                }
+                break
+            }
+            if (idx >= leaves.size) return null
+            val firstLeaf = leaves[idx]
+            // The marker start offset is the start of `[`
+            if (firstLeaf.getTextInNode(text).toString().trimStart() != "[") return null
+            val markerStart = firstLeaf.startOffset
+            // Scan forward for `]` within a few leaves
+            var j = idx + 1
+            while (j < leaves.size && j < idx + 8) {
+                if (leaves[j].getTextInNode(text) == "]") {
+                    return markerStart..leaves[j].endOffset
+                }
+                j++
+            }
+            return null
+        }
+
+        private fun collectLeaves(node: ASTNode): List<ASTNode> {
+            if (node.children.isEmpty()) return listOf(node)
+            return node.children.flatMap { collectLeaves(it) }
+        }
+    }
+}

--- a/src/commonMain/kotlin/org/intellij/markdown/flavours/glfm/GLFMGeneratingProviders.kt
+++ b/src/commonMain/kotlin/org/intellij/markdown/flavours/glfm/GLFMGeneratingProviders.kt
@@ -1,0 +1,430 @@
+package org.intellij.markdown.flavours.glfm
+
+import org.intellij.markdown.MarkdownElementTypes
+import org.intellij.markdown.MarkdownTokenTypes
+import org.intellij.markdown.ast.ASTNode
+import org.intellij.markdown.ast.acceptChildren
+import org.intellij.markdown.ast.getTextInNode
+import org.intellij.markdown.html.GeneratingProvider
+import org.intellij.markdown.html.HtmlGenerator
+
+/**
+ * Generating provider for the GitLab `>>>` multiline blockquote.
+ *
+ * The block parser wraps everything between the opening and closing `>>>` in a
+ * MULTILINE_BLOCK_QUOTE node. That node's children will include nested
+ * BLOCK_QUOTE nodes from the fence lines themselves, plus the actual content
+ * (paragraphs, etc.) between them.  We render only the content, skipping the
+ * fence-line BLOCK_QUOTE children, inside a single `<blockquote>`.
+ */
+class MultilineBlockQuoteGeneratingProvider : GeneratingProvider {
+    override fun processNode(
+        visitor: HtmlGenerator.HtmlGeneratingVisitor,
+        text: String,
+        node: ASTNode,
+    ) {
+        visitor.consumeTagOpen(node, "blockquote")
+        // The node's children are:
+        //   WHITE_SPACE(">")  BLOCK_QUOTE(..)  EOL   ← opening fence line remnants
+        //   PARAGRAPH ...
+        //   ...
+        //   MULTILINE_BLOCK_QUOTE(>>>)               ← closing fence
+        // We skip the first non-EOL "fence" group and the last MULTILINE_BLOCK_QUOTE.
+        val children = node.children
+
+        // Skip leading fence tokens (WHITE_SPACE ">" and any BLOCK_QUOTE from the `>>` part)
+        var start = 0
+        while (start < children.size) {
+            val t = children[start].type
+            if (t == MarkdownTokenTypes.WHITE_SPACE ||
+                t == MarkdownElementTypes.BLOCK_QUOTE ||
+                t == MarkdownTokenTypes.EOL) {
+                start++
+            } else {
+                break
+            }
+        }
+
+        // Skip trailing closing fence (MULTILINE_BLOCK_QUOTE and trailing EOL)
+        var end = children.size - 1
+        while (end >= start) {
+            val t = children[end].type
+            if (t == GLFMElementTypes.MULTILINE_BLOCK_QUOTE ||
+                t == MarkdownTokenTypes.EOL) {
+                end--
+            } else {
+                break
+            }
+        }
+
+        for (i in start..end) {
+            visitor.visitNode(children[i])
+        }
+        visitor.consumeTagClose("blockquote")
+    }
+}
+
+/**
+ * Generating provider for inline diffs (additions and deletions).
+ *
+ * Renders:
+ * - `{+ added text +}` / `{+text+}` as `<span class="idiff addition">…</span>`
+ * - `[- deleted text -]` / `[-text-]` as `<span class="idiff deletion">…</span>`
+ *
+ * Node shapes produced by [InlineDiffParser]:
+ * - Addition, single token:  [TEXT("{+text+}")]
+ * - Addition, multi token:   [TEXT("{+"), …content…, TEXT("+}[trailing]")]
+ * - Deletion, single content: [LBRACKET, TEXT("-text-"), RBRACKET]
+ * - Deletion, multi token:    [LBRACKET, TEXT("-"), …content…, TEXT("-"), RBRACKET]
+ */
+class InlineDiffGeneratingProvider : GeneratingProvider {
+    override fun processNode(
+        visitor: HtmlGenerator.HtmlGeneratingVisitor,
+        text: String,
+        node: ASTNode
+    ) {
+        val content = node.getTextInNode(text).toString()
+        val children = node.children
+
+        val isAddition = content.startsWith("{+")
+        val isDeletion = !isAddition && content.startsWith("[-")
+        if (!isAddition && !isDeletion) {
+            node.acceptChildren(visitor)
+            return
+        }
+        val cssClass = if (isAddition) "addition" else "deletion"
+
+        // Determine content child range and any trailing text after the close marker
+        var from = 0
+        var to = -1
+        var singleTokenInner: String? = null
+        var trailing = ""
+
+        if (isAddition) {
+            if (children.size == 1) {
+                // "{+text+}" — one TEXT token
+                singleTokenInner = content.substring(2, content.length - 2)
+            } else {
+                from = 1
+                to = children.size - 2
+                val closingText = children.last().getTextInNode(text).toString()
+                if (closingText.length > 2) trailing = closingText.substring(2)
+            }
+        } else {
+            if (children.size == 3) {
+                // LBRACKET + TEXT("-text-") + RBRACKET
+                val inner = children[1].getTextInNode(text).toString()
+                singleTokenInner = inner.substring(1, inner.length - 1)
+            } else {
+                from = 2
+                to = children.size - 3
+            }
+        }
+
+        visitor.consumeTagOpen(node, "span", "class=\"idiff $cssClass\"")
+        if (singleTokenInner != null) {
+            visitor.consumeHtml(singleTokenInner)
+        } else {
+            for (i in from..to) {
+                val child = children[i]
+                if (child.children.isEmpty()) {
+                    visitor.visitLeaf(child)
+                } else {
+                    visitor.visitNode(child)
+                }
+            }
+        }
+        visitor.consumeTagClose("span")
+
+        if (trailing.isNotEmpty()) {
+            visitor.consumeHtml(trailing)
+        }
+    }
+}
+
+/**
+ * Generating provider for emoji shortcodes.
+ *
+ * Renders `:emoji_name:` as either:
+ * - Unicode emoji (if mapping is available)
+ * - `<span class="gl-emoji" data-name="emoji_name" title=":emoji_name:">:emoji_name:</span>`
+ *
+ * The actual emoji rendering can be customized by providing an emoji map.
+ */
+class EmojiGeneratingProvider(
+    private val emojiMap: Map<String, String> = DEFAULT_EMOJI_MAP
+) : GeneratingProvider {
+    override fun processNode(
+        visitor: HtmlGenerator.HtmlGeneratingVisitor,
+        text: String,
+        node: ASTNode
+    ) {
+        val fullText = node.getTextInNode(text).toString()
+
+        // Extract emoji name (remove surrounding colons)
+        val emojiName = if (fullText.startsWith(":") && fullText.endsWith(":")) {
+            fullText.substring(1, fullText.length - 1)
+        } else {
+            fullText
+        }
+
+        // Look up emoji in map
+        val emoji = emojiMap[emojiName]
+
+        if (emoji != null) {
+            // Render as Unicode emoji
+            visitor.consumeTagOpen(
+                node,
+                "span",
+                "class=\"gl-emoji\"",
+                "data-name=\"$emojiName\"",
+                "title=\":$emojiName:\""
+            )
+            visitor.consumeHtml(emoji)
+            visitor.consumeTagClose("span")
+        } else {
+            // Fallback to showing the shortcode
+            visitor.consumeTagOpen(
+                node,
+                "span",
+                "class=\"gl-emoji\"",
+                "data-name=\"$emojiName\"",
+                "title=\":$emojiName:\""
+            )
+            visitor.consumeHtml(":$emojiName:")
+            visitor.consumeTagClose("span")
+        }
+    }
+
+    companion object {
+        /**
+         * Default emoji map with common emojis.
+         * In a real implementation, this would be much more comprehensive.
+         */
+        val DEFAULT_EMOJI_MAP = mapOf(
+            "smile" to "😄",
+            "laughing" to "😆",
+            "blush" to "😊",
+            "heart" to "❤️",
+            "thumbsup" to "👍",
+            "thumbsdown" to "👎",
+            "+1" to "👍",
+            "-1" to "👎",
+            "ok_hand" to "👌",
+            "wave" to "👋",
+            "tada" to "🎉",
+            "rocket" to "🚀",
+            "fire" to "🔥",
+            "sparkles" to "✨",
+            "star" to "⭐",
+            "white_check_mark" to "✅",
+            "x" to "❌",
+            "warning" to "⚠️",
+            "bulb" to "💡",
+            "book" to "📖",
+            "pencil" to "📝",
+            "mag" to "🔍",
+            "link" to "🔗",
+            "lock" to "🔒",
+            "unlock" to "🔓",
+            "eyes" to "👀",
+            "thinking" to "🤔",
+            "clap" to "👏",
+            "muscle" to "💪"
+        )
+    }
+}
+
+/**
+ * Generating provider for GitLab references.
+ *
+ * Renders references as links with appropriate classes:
+ * - `@username` -> User profile link
+ * - `#123` -> Issue link
+ * - `!123` -> Merge request link
+ * - `$123` -> Snippet link
+ * - `&123` -> Epic link
+ * - `~label` -> Label link
+ * - `%milestone` -> Milestone link
+ *
+ * The base URL for links can be customized.
+ */
+class GitLabReferenceGeneratingProvider(
+    private val baseUrl: String = "",
+    private val currentProject: String = ""
+) : GeneratingProvider {
+    override fun processNode(
+        visitor: HtmlGenerator.HtmlGeneratingVisitor,
+        text: String,
+        node: ASTNode
+    ) {
+        val raw = node.getTextInNode(text).toString()
+        if (raw.isEmpty()) return
+
+        // Trim trailing punctuation that got included in the token
+        val refText = trimTrailingPunctuation(raw)
+        val suffix = raw.substring(refText.length)
+
+        val (url, cssClass, title) = parseReference(refText)
+
+        if (url != null) {
+            visitor.consumeTagOpen(
+                node,
+                "a",
+                "href=\"$url\"",
+                "class=\"gfm $cssClass\"",
+                "title=\"$title\""
+            )
+            visitor.consumeHtml(refText)
+            visitor.consumeTagClose("a")
+            if (suffix.isNotEmpty()) visitor.consumeHtml(suffix)
+        } else {
+            visitor.consumeHtml(raw)
+        }
+    }
+
+    private fun trimTrailingPunctuation(s: String): String {
+        if (s.isEmpty()) return s
+        val marker = s[0]
+        return when (marker) {
+            '@' -> {
+                // scan past '@' then take valid username chars
+                var end = 1
+                while (end < s.length && isValidUsernameChar(s[end])) end++
+                s.substring(0, end)
+            }
+            '#', '!', '&', '$' -> {
+                var end = 1
+                while (end < s.length && s[end].isDigit()) end++
+                s.substring(0, end)
+            }
+            '%' -> {
+                var end = 1
+                while (end < s.length && (s[end].isLetterOrDigit() || s[end] == '.' || s[end] == '_' || s[end] == '-')) end++
+                s.substring(0, end)
+            }
+            '~' -> {
+                // Quoted label ~"multi word" — keep everything up to the closing quote
+                if (s.length > 1 && s[1] == '"') {
+                    val close = s.indexOf('"', 2)
+                    if (close > 0) s.substring(0, close + 1) else s
+                } else {
+                    var end = 1
+                    while (end < s.length && (s[end].isLetterOrDigit() || s[end] == '_' || s[end] == '-')) end++
+                    s.substring(0, end)
+                }
+            }
+            else -> s
+        }
+    }
+
+    private fun isValidUsernameChar(c: Char) = c.isLetterOrDigit() || c == '_' || c == '-' || c == '.'
+
+    private fun parseReference(refText: String): Triple<String?, String, String> {
+        if (refText.isEmpty()) return Triple(null, "", "")
+
+        val marker = refText[0]
+
+        return when (marker) {
+            '@' -> {
+                val username = refText.substring(1)
+                Triple(
+                    "$baseUrl/$username",
+                    "gfm-project_member",
+                    "User: $username"
+                )
+            }
+
+            '#' -> {
+                val (project, id) = parseProjectReference(refText.substring(1))
+                val projectPath = project ?: currentProject
+                Triple(
+                    "$baseUrl/$projectPath/-/issues/$id",
+                    "gfm-issue",
+                    "Issue #$id"
+                )
+            }
+
+            '!' -> {
+                val (project, id) = parseProjectReference(refText.substring(1))
+                val projectPath = project ?: currentProject
+                Triple(
+                    "$baseUrl/$projectPath/-/merge_requests/$id",
+                    "gfm-merge_request",
+                    "Merge request !$id"
+                )
+            }
+
+            '$' -> {
+                val (project, id) = parseProjectReference(refText.substring(1))
+                val projectPath = project ?: currentProject
+                Triple(
+                    "$baseUrl/$projectPath/-/snippets/$id",
+                    "gfm-snippet",
+                    "Snippet \$$id"
+                )
+            }
+
+            '&' -> {
+                val id = refText.substring(1)
+                Triple(
+                    "$baseUrl/groups/$currentProject/-/epics/$id",
+                    "gfm-epic",
+                    "Epic &$id"
+                )
+            }
+
+            '~' -> {
+                val label = refText.substring(1).trim('"')
+                Triple(
+                    "$baseUrl/$currentProject/-/issues?label_name[]=$label",
+                    "gfm-label",
+                    "Label: $label"
+                )
+            }
+
+            '%' -> {
+                val milestone = refText.substring(1).trim('"')
+                Triple(
+                    "$baseUrl/$currentProject/-/milestones",
+                    "gfm-milestone",
+                    "Milestone: $milestone"
+                )
+            }
+
+            else -> {
+                // Cross-project reference: group/project#123
+                val hashIdx = refText.indexOf('#')
+                if (hashIdx > 0) {
+                    val projectPath = refText.substring(0, hashIdx)
+                    val id = refText.substring(hashIdx + 1)
+                    Triple(
+                        "$baseUrl/$projectPath/-/issues/$id",
+                        "gfm-issue",
+                        "Issue #$id in $projectPath"
+                    )
+                } else {
+                    Triple(null, "", "")
+                }
+            }
+        }
+    }
+
+    /**
+     * Parse a reference that may include a project path.
+     * Returns (project, id) where project may be null if not specified.
+     */
+    private fun parseProjectReference(ref: String): Pair<String?, String> {
+        val lastMarkerIndex = ref.lastIndexOfAny(charArrayOf('#', '!', '$'))
+
+        if (lastMarkerIndex > 0) {
+            // Has project prefix
+            val project = ref.substring(0, lastMarkerIndex)
+            val id = ref.substring(lastMarkerIndex + 1)
+            return project to id
+        }
+
+        // No project prefix
+        return null to ref
+    }
+}

--- a/src/commonMain/kotlin/org/intellij/markdown/flavours/glfm/GLFMMarkerProcessor.kt
+++ b/src/commonMain/kotlin/org/intellij/markdown/flavours/glfm/GLFMMarkerProcessor.kt
@@ -1,0 +1,66 @@
+package org.intellij.markdown.flavours.glfm
+
+import org.intellij.markdown.MarkdownTokenTypes
+import org.intellij.markdown.flavours.commonmark.CommonMarkMarkerProcessor
+import org.intellij.markdown.flavours.gfm.GFMConstraints
+import org.intellij.markdown.flavours.gfm.GFMTokenTypes
+import org.intellij.markdown.flavours.gfm.table.GitHubTableMarkerProvider
+import org.intellij.markdown.parser.LookaheadText
+import org.intellij.markdown.parser.MarkerProcessor
+import org.intellij.markdown.parser.MarkerProcessorFactory
+import org.intellij.markdown.parser.ProductionHolder
+import org.intellij.markdown.parser.constraints.CommonMarkdownConstraints
+import org.intellij.markdown.parser.constraints.MarkdownConstraints
+import org.intellij.markdown.parser.constraints.getCharsEaten
+import org.intellij.markdown.parser.markerblocks.MarkerBlockProvider
+import org.intellij.markdown.parser.sequentialparsers.SequentialParser
+import kotlin.math.min
+
+class GLFMMarkerProcessor(
+    productionHolder: ProductionHolder,
+    constraintsBase: CommonMarkdownConstraints,
+) : CommonMarkMarkerProcessor(productionHolder, constraintsBase) {
+
+    private val glfmProviders = listOf(MultilineBlockQuoteProvider()) +
+        super.getMarkerBlockProviders() +
+        listOf(GitHubTableMarkerProvider())
+
+    override fun getMarkerBlockProviders(): List<MarkerBlockProvider<StateInfo>> = glfmProviders
+
+    override fun populateConstraintsTokens(
+        pos: LookaheadText.Position,
+        constraints: MarkdownConstraints,
+        productionHolder: ProductionHolder,
+    ) {
+        if (constraints !is GFMConstraints || !constraints.hasCheckbox()) {
+            super.populateConstraintsTokens(pos, constraints, productionHolder)
+            return
+        }
+        val line = pos.currentLine
+        var offset = pos.offsetInCurrentLine
+        while (offset < line.length && line[offset] != '[') offset++
+        if (offset == line.length) {
+            super.populateConstraintsTokens(pos, constraints, productionHolder)
+            return
+        }
+        val type = when (constraints.types.lastOrNull()) {
+            '>' -> MarkdownTokenTypes.BLOCK_QUOTE
+            '.', ')' -> MarkdownTokenTypes.LIST_NUMBER
+            else -> MarkdownTokenTypes.LIST_BULLET
+        }
+        val middleOffset = pos.offset - pos.offsetInCurrentLine + offset
+        val endOffset = min(
+            pos.offset - pos.offsetInCurrentLine + constraints.getCharsEaten(pos.currentLine),
+            pos.nextLineOrEofOffset
+        )
+        productionHolder.addProduction(listOf(
+            SequentialParser.Node(pos.offset..middleOffset, type),
+            SequentialParser.Node(middleOffset..endOffset, GFMTokenTypes.CHECK_BOX),
+        ))
+    }
+
+    object Factory : MarkerProcessorFactory {
+        override fun createMarkerProcessor(productionHolder: ProductionHolder): MarkerProcessor<*> =
+            GLFMMarkerProcessor(productionHolder, GFMConstraints.BASE)
+    }
+}

--- a/src/commonMain/kotlin/org/intellij/markdown/flavours/glfm/GitLabReferenceParser.kt
+++ b/src/commonMain/kotlin/org/intellij/markdown/flavours/glfm/GitLabReferenceParser.kt
@@ -1,0 +1,192 @@
+package org.intellij.markdown.flavours.glfm
+
+import org.intellij.markdown.MarkdownTokenTypes
+import org.intellij.markdown.flavours.gfm.GFMTokenTypes
+import org.intellij.markdown.parser.sequentialparsers.RangesListBuilder
+import org.intellij.markdown.parser.sequentialparsers.SequentialParser
+import org.intellij.markdown.parser.sequentialparsers.TokensCache
+
+/**
+ * Parser for GitLab-specific references.
+ *
+ * Token shapes from GFM lexer (whitespace is filtered by sequential parser):
+ *   @username  → single TEXT token (may include trailing punctuation)
+ *   #123       → single TEXT token starting with '#'
+ *   !456       → EXCLAMATION_MARK token + TEXT token "456"
+ *   group/project#123 → single TEXT token
+ *   ~label     → GFMTokenTypes.TILDE token + TEXT token
+ *   %milestone → TEXT token starting with '%'
+ *   &123       → TEXT token starting with '&'
+ *
+ * We only emit a GITLAB_REFERENCE when we consume complete token(s).
+ */
+class GitLabReferenceParser : SequentialParser {
+    override fun parse(tokens: TokensCache, rangesToGlue: List<IntRange>): SequentialParser.ParsingResult {
+        val result = SequentialParser.ParsingResultBuilder()
+        val delegateIndices = RangesListBuilder()
+        var iterator: TokensCache.Iterator = tokens.RangesListIterator(rangesToGlue)
+
+        while (iterator.type != null) {
+            val consumed = detectReference(tokens, iterator)
+            if (consumed != null) {
+                result.withNode(
+                    SequentialParser.Node(
+                        iterator.index..consumed + 1,
+                        GLFMElementTypes.GITLAB_REFERENCE
+                    )
+                )
+                var cur = iterator
+                while (cur.index <= consumed) cur = cur.advance()
+                iterator = cur
+            } else {
+                delegateIndices.put(iterator.index)
+                iterator = iterator.advance()
+            }
+        }
+
+        return result.withFurtherProcessing(delegateIndices.get())
+    }
+
+    /**
+     * Returns the last consumed token index, or null if no reference detected.
+     */
+    private fun detectReference(tokens: TokensCache, it: TokensCache.Iterator): Int? {
+        // !NNN  — EXCLAMATION_MARK + TEXT starting with digits
+        if (it.type == MarkdownTokenTypes.EXCLAMATION_MARK) {
+            val next = it.advance()
+            if (next.type == MarkdownTokenTypes.TEXT) {
+                val t = tokenText(tokens, next)
+                // First char must be a digit; digits must end at a word boundary
+                // (trailing punctuation is fine — the generator trims it)
+                if (t.isNotEmpty() && t[0].isDigit() && hasDigitBoundary(t, 0)) {
+                    return next.index
+                }
+            }
+            return null
+        }
+
+        // $NNN  — DOLLAR token (GFM math token) + TEXT starting with digits
+        if (it.type == GFMTokenTypes.DOLLAR && it.length == 1) {
+            val next = it.advance()
+            if (next.type == MarkdownTokenTypes.TEXT && next.length > 0) {
+                val t = tokenText(tokens, next)
+                if (t[0].isDigit() && hasDigitBoundary(t, 0)) {
+                    return next.index
+                }
+            }
+            return null
+        }
+
+        // TILDE → ~label or ~"multi word label" (but NOT ~~strikethrough~~)
+        if (it.type == GFMTokenTypes.TILDE) {
+            val next = it.advance()
+            // If next token is also TILDE → ~~text~~ strikethrough opener, skip
+            if (next.type == GFMTokenTypes.TILDE) return null
+            // If the raw token immediately before this TILDE is also TILDE → we are
+            // the second ~ of ~~, which means we're inside strikethrough context
+            if (it.rawLookup(-1) == GFMTokenTypes.TILDE) return null
+
+            // Quoted label: ~"multi word" → TILDE, DOUBLE_QUOTE, TEXT…, DOUBLE_QUOTE
+            if (next.type == MarkdownTokenTypes.DOUBLE_QUOTE) {
+                var cur = next.advance()
+                var sawContent = false
+                while (cur.type != null &&
+                    cur.type != MarkdownTokenTypes.DOUBLE_QUOTE &&
+                    cur.type != MarkdownTokenTypes.EOL
+                ) {
+                    sawContent = true
+                    cur = cur.advance()
+                }
+                if (sawContent && cur.type == MarkdownTokenTypes.DOUBLE_QUOTE) {
+                    return cur.index
+                }
+                return null
+            }
+
+            if (next.type == MarkdownTokenTypes.TEXT) {
+                val t = tokenText(tokens, next)
+                // Accept if starts with at least one valid label char — generator trims trailing
+                val label = t.takeWhile { c -> c.isLetterOrDigit() || c == '_' || c == '-' }
+                if (label.isNotEmpty()) {
+                    return next.index
+                }
+            }
+            return null
+        }
+
+        // TEXT token with embedded reference marker
+        if (it.type == MarkdownTokenTypes.TEXT) {
+            val t = tokenText(tokens, it)
+            if (t.isEmpty()) return null
+            return when (t[0]) {
+                '@' -> detectUserMention(it, t)
+                '#' -> detectNumericRef(it, t, 1)
+                '%' -> detectAlphanumRef(it, t, 1)
+                '&' -> detectNumericRef(it, t, 1)
+                '$' -> detectNumericRef(it, t, 1)
+                else -> detectCrossProjectRef(it, t)
+            }
+        }
+
+        return null
+    }
+
+    private fun detectUserMention(it: TokensCache.Iterator, t: String): Int? {
+        if (t.length <= 1) return null
+        var pos = 1
+        while (pos < t.length && isValidUsernameChar(t[pos])) pos++
+        // require at least 1 valid username char after '@'
+        if (pos <= 1) return null
+        // Accept even if token has trailing punctuation — generator will trim
+        return it.index
+    }
+
+    private fun detectNumericRef(it: TokensCache.Iterator, t: String, startPos: Int): Int? {
+        if (t.length <= startPos) return null
+        var pos = startPos
+        while (pos < t.length && t[pos].isDigit()) pos++
+        if (pos == startPos) return null // no digits
+        // Require a word boundary after the digits: `#123abc` is NOT a reference
+        if (pos < t.length && t[pos].isLetter()) return null
+        return it.index
+    }
+
+    /** Like detectNumericRef but also allows letters (for milestone names like %v1.0). */
+    private fun detectAlphanumRef(it: TokensCache.Iterator, t: String, startPos: Int): Int? {
+        if (t.length <= startPos) return null
+        var pos = startPos
+        while (pos < t.length && (t[pos].isLetterOrDigit() || t[pos] == '.' || t[pos] == '_' || t[pos] == '-')) pos++
+        if (pos == startPos) return null
+        return it.index
+    }
+
+    private fun detectCrossProjectRef(it: TokensCache.Iterator, t: String): Int? {
+        val hashIdx = t.indexOf('#')
+        if (hashIdx <= 0) return null
+        val prefix = t.substring(0, hashIdx)
+        if (!isNamespacePath(prefix)) return null
+        val id = t.substring(hashIdx + 1)
+        if (id.isEmpty() || !id.all { it2 -> it2.isDigit() }) return null
+        return it.index
+    }
+
+    private fun tokenText(tokens: TokensCache, it: TokensCache.Iterator): String {
+        val sb = StringBuilder(it.length)
+        for (i in it.start until it.end) sb.append(tokens.getRawCharAt(i))
+        return sb.toString()
+    }
+
+    private fun isNamespacePath(s: String): Boolean {
+        if (s.isEmpty()) return false
+        return s.all { c -> c.isLetterOrDigit() || c == '_' || c == '-' || c == '.' || c == '/' }
+    }
+
+    private fun isValidUsernameChar(c: Char) = c.isLetterOrDigit() || c == '_' || c == '-' || c == '.'
+
+    /** True when the digit run starting at [startPos] ends at a word boundary (not a letter). */
+    private fun hasDigitBoundary(t: String, startPos: Int): Boolean {
+        var pos = startPos
+        while (pos < t.length && t[pos].isDigit()) pos++
+        return pos >= t.length || !t[pos].isLetter()
+    }
+}

--- a/src/commonMain/kotlin/org/intellij/markdown/flavours/glfm/InlineDiffParser.kt
+++ b/src/commonMain/kotlin/org/intellij/markdown/flavours/glfm/InlineDiffParser.kt
@@ -1,0 +1,126 @@
+package org.intellij.markdown.flavours.glfm
+
+import org.intellij.markdown.IElementType
+import org.intellij.markdown.MarkdownTokenTypes
+import org.intellij.markdown.parser.sequentialparsers.RangesListBuilder
+import org.intellij.markdown.parser.sequentialparsers.SequentialParser
+import org.intellij.markdown.parser.sequentialparsers.TokensCache
+
+/**
+ * Parser for GitLab inline diff syntax.
+ *
+ * Supports:
+ * - Additions: `{+ added text +}` or `{+added text+}`
+ * - Deletions: `[- deleted text -]` or `[-deleted text-]`
+ *
+ * Restrictions (matching GitLab behaviour):
+ * - The diff must open and close on the same line (no EOL inside).
+ *
+ * Token shapes from the GFM lexer:
+ * - `{+`  → TEXT token starting with those chars (may be longer, e.g. `{+nospace+}` is one token)
+ * - `[-`  → LBRACKET + TEXT starting with `-`
+ * - `+}`  → TEXT token whose first two chars are `+}` (may include trailing punctuation)
+ * - `-]`  → TEXT ending with `-` + RBRACKET
+ */
+class InlineDiffParser : SequentialParser {
+    override fun parse(tokens: TokensCache, rangesToGlue: List<IntRange>): SequentialParser.ParsingResult {
+        val result = SequentialParser.ParsingResultBuilder()
+        val delegateIndices = RangesListBuilder()
+        var iterator: TokensCache.Iterator = tokens.RangesListIterator(rangesToGlue)
+
+        while (iterator.type != null) {
+            val node = detectDiff(tokens, iterator)
+            if (node != null) {
+                result.withNode(node)
+                // advance past the node's last token
+                var cur = iterator
+                while (cur.index < node.range.last) cur = cur.advance()
+                iterator = cur
+                continue
+            }
+            delegateIndices.put(iterator.index)
+            iterator = iterator.advance()
+        }
+
+        return result.withFurtherProcessing(delegateIndices.get())
+    }
+
+    private fun detectDiff(tokens: TokensCache, it: TokensCache.Iterator): SequentialParser.Node? {
+        // ── Addition ────────────────────────────────────────────────────────
+        // Opening: TEXT token starting with "{+"
+        if (it.type == MarkdownTokenTypes.TEXT && it.length >= 2 &&
+            tokens.getRawCharAt(it.start) == '{' && tokens.getRawCharAt(it.start + 1) == '+'
+        ) {
+            // Single-token form: "{+text+}" — one TEXT token that also ends with "+}"
+            if (it.length >= 4 &&
+                tokens.getRawCharAt(it.end - 2) == '+' && tokens.getRawCharAt(it.end - 1) == '}'
+            ) {
+                return SequentialParser.Node(it.index..it.index + 1, GLFMElementTypes.INLINE_DIFF_ADDITION)
+            }
+            // Multi-token form: "{+" … "+}"
+            val close = findAdditionClose(tokens, it.advance())
+            if (close != null) {
+                return SequentialParser.Node(it.index..close.index + 1, GLFMElementTypes.INLINE_DIFF_ADDITION)
+            }
+        }
+
+        // ── Deletion ────────────────────────────────────────────────────────
+        // Opening: LBRACKET + TEXT starting with "-"
+        if (it.type == MarkdownTokenTypes.LBRACKET) {
+            val next = it.advance()
+            if (next.type == MarkdownTokenTypes.TEXT && next.length >= 1 &&
+                tokens.getRawCharAt(next.start) == '-'
+            ) {
+                // Single-token content form: "[-text-]" → LBRACKET + TEXT("-text-") + RBRACKET
+                if (next.length >= 2 && tokens.getRawCharAt(next.end - 1) == '-') {
+                    val after = next.advance()
+                    if (after.type == MarkdownTokenTypes.RBRACKET) {
+                        return SequentialParser.Node(it.index..after.index + 1, GLFMElementTypes.INLINE_DIFF_DELETION)
+                    }
+                }
+                // Multi-token form: LBRACKET TEXT("-") … TEXT("-") RBRACKET
+                if (next.length == 1) {
+                    val close = findDeletionClose(tokens, next.advance())
+                    if (close != null) {
+                        return SequentialParser.Node(it.index..close.index + 1, GLFMElementTypes.INLINE_DIFF_DELETION)
+                    }
+                }
+            }
+        }
+
+        return null
+    }
+
+    /** Finds a TEXT token whose first two chars are `+}` on the same line. */
+    private fun findAdditionClose(tokens: TokensCache, from: TokensCache.Iterator): TokensCache.Iterator? {
+        var cur = from
+        while (cur.type != null) {
+            if (cur.type == MarkdownTokenTypes.EOL) return null // must not span lines
+            if (cur.type == MarkdownTokenTypes.TEXT && cur.length >= 2 &&
+                tokens.getRawCharAt(cur.start) == '+' && tokens.getRawCharAt(cur.start + 1) == '}'
+            ) {
+                return cur
+            }
+            cur = cur.advance()
+        }
+        return null
+    }
+
+    /** Finds TEXT("-") followed by RBRACKET on the same line; returns the RBRACKET iterator. */
+    private fun findDeletionClose(tokens: TokensCache, from: TokensCache.Iterator): TokensCache.Iterator? {
+        var cur = from
+        while (cur.type != null) {
+            if (cur.type == MarkdownTokenTypes.EOL) return null // must not span lines
+            if (cur.type == MarkdownTokenTypes.TEXT && cur.length == 1 &&
+                tokens.getRawCharAt(cur.start) == '-'
+            ) {
+                val next = cur.advance()
+                if (next.type == MarkdownTokenTypes.RBRACKET) {
+                    return next
+                }
+            }
+            cur = cur.advance()
+        }
+        return null
+    }
+}

--- a/src/commonMain/kotlin/org/intellij/markdown/flavours/glfm/MultilineBlockQuoteMarkerBlock.kt
+++ b/src/commonMain/kotlin/org/intellij/markdown/flavours/glfm/MultilineBlockQuoteMarkerBlock.kt
@@ -1,0 +1,55 @@
+package org.intellij.markdown.flavours.glfm
+
+import org.intellij.markdown.IElementType
+import org.intellij.markdown.parser.LookaheadText
+import org.intellij.markdown.parser.ProductionHolder
+import org.intellij.markdown.parser.constraints.MarkdownConstraints
+import org.intellij.markdown.parser.markerblocks.MarkerBlock
+import org.intellij.markdown.parser.markerblocks.MarkerBlockImpl
+
+/**
+ * Marker block for GitLab multiline blockquote syntax.
+ *
+ * A `>>>` on its own line opens the block; the next `>>>` on its own line closes it.
+ * Content between the fence lines is emitted as BLOCK_QUOTE content, allowing
+ * the normal paragraph / inline parsers to process it.
+ */
+class MultilineBlockQuoteMarkerBlock(
+    myConstraints: MarkdownConstraints,
+    productionHolder: ProductionHolder,
+) : MarkerBlockImpl(myConstraints, productionHolder.mark()) {
+
+    override fun allowsSubBlocks(): Boolean = true
+
+    override fun isInterestingOffset(pos: LookaheadText.Position): Boolean = true
+
+    override fun calcNextInterestingOffset(pos: LookaheadText.Position): Int =
+        pos.nextLineOrEofOffset
+
+    override fun getDefaultAction(): MarkerBlock.ClosingAction =
+        MarkerBlock.ClosingAction.DONE
+
+    override fun doProcessToken(
+        pos: LookaheadText.Position,
+        currentConstraints: MarkdownConstraints,
+    ): MarkerBlock.ProcessingResult {
+        if (pos.offsetInCurrentLine != -1) {
+            return MarkerBlock.ProcessingResult.CANCEL
+        }
+
+        if (isClosingFence(pos.currentLine)) {
+            scheduleProcessingResult(pos.nextLineOrEofOffset, MarkerBlock.ProcessingResult.DEFAULT)
+        }
+
+        return MarkerBlock.ProcessingResult.CANCEL
+    }
+
+    override fun getDefaultNodeType(): IElementType = GLFMElementTypes.MULTILINE_BLOCK_QUOTE
+
+    companion object {
+        const val FENCE = ">>>"
+
+        fun isClosingFence(line: CharSequence): Boolean =
+            line.trim() == FENCE
+    }
+}

--- a/src/commonMain/kotlin/org/intellij/markdown/flavours/glfm/MultilineBlockQuoteProvider.kt
+++ b/src/commonMain/kotlin/org/intellij/markdown/flavours/glfm/MultilineBlockQuoteProvider.kt
@@ -1,0 +1,38 @@
+package org.intellij.markdown.flavours.glfm
+
+import org.intellij.markdown.parser.LookaheadText
+import org.intellij.markdown.parser.MarkerProcessor
+import org.intellij.markdown.parser.ProductionHolder
+import org.intellij.markdown.parser.constraints.MarkdownConstraints
+import org.intellij.markdown.parser.markerblocks.MarkerBlock
+import org.intellij.markdown.parser.markerblocks.MarkerBlockProvider
+
+/**
+ * Provides [MultilineBlockQuoteMarkerBlock] when a line consisting solely of
+ * `>>>` is encountered.
+ */
+class MultilineBlockQuoteProvider : MarkerBlockProvider<MarkerProcessor.StateInfo> {
+
+    override fun createMarkerBlocks(
+        pos: LookaheadText.Position,
+        productionHolder: ProductionHolder,
+        stateInfo: MarkerProcessor.StateInfo,
+    ): List<MarkerBlock> {
+        if (!isFenceLine(pos)) return emptyList()
+
+        return listOf(
+            MultilineBlockQuoteMarkerBlock(stateInfo.currentConstraints, productionHolder)
+        )
+    }
+
+    override fun interruptsParagraph(
+        pos: LookaheadText.Position,
+        constraints: MarkdownConstraints,
+    ): Boolean = isFenceLine(pos)
+
+    companion object {
+        fun isFenceLine(pos: LookaheadText.Position): Boolean =
+            pos.currentLine.trim() == MultilineBlockQuoteMarkerBlock.FENCE &&
+            pos.currentLineFromPosition.trimEnd() == MultilineBlockQuoteMarkerBlock.FENCE
+    }
+}

--- a/src/commonTest/kotlin/org/intellij/markdown/flavours/glfm/GLFMFeaturesTest.kt
+++ b/src/commonTest/kotlin/org/intellij/markdown/flavours/glfm/GLFMFeaturesTest.kt
@@ -1,0 +1,649 @@
+package org.intellij.markdown.flavours.glfm
+
+import org.intellij.markdown.html.HtmlGenerator
+import org.intellij.markdown.parser.MarkdownParser
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Comprehensive tests for every GitLab Flavored Markdown (GLFM) feature.
+ *
+ * Covers:
+ *  1. Inline diffs  ({+ addition +}, [- deletion -])
+ *  2. Emoji shortcodes  (:name:)
+ *  3. GitLab references (@user, #issue, !mr, $snippet, &epic, ~label, %milestone,
+ *     cross-project group/project#id)
+ *  4. Alerts  (> [!note/tip/important/caution/warning])
+ *  5. Multiline blockquotes  (>>> … >>>)
+ *  6. Math (inherited from GFM — $…$ and $$…$$)
+ *  7. Strikethrough (inherited from GFM — ~~text~~)
+ *  8. Tables (inherited from GFM)
+ *  9. Task lists (inherited from GFM)
+ * 10. Edge cases and interactions between features
+ */
+class GLFMFeaturesTest {
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private fun render(
+        markdown: String,
+        baseUrl: String = "https://gitlab.com",
+        project: String = "mygroup/myproject",
+    ): String {
+        val flavour = GLFMFlavourDescriptor(
+            gitlabBaseUrl = baseUrl,
+            gitlabProject = project,
+        )
+        val tree = MarkdownParser(flavour).buildMarkdownTreeFromString(markdown)
+        return HtmlGenerator(markdown, tree, flavour).generateHtml()
+    }
+
+    private fun assertContains(html: String, vararg substrings: String) {
+        for (s in substrings) assertTrue(html.contains(s), "Expected '$s' in:\n$html")
+    }
+
+    private fun assertNotContains(html: String, vararg substrings: String) {
+        for (s in substrings) assertFalse(html.contains(s), "Did not expect '$s' in:\n$html")
+    }
+
+    // ── 1. Inline diffs ──────────────────────────────────────────────────────
+
+    @Test fun inlineDiffAdditionBasic() {
+        val html = render("{+ added text +}")
+        assertContains(html, """class="idiff addition"""", "added text")
+        assertContains(html, "<span", "</span>")
+    }
+
+    @Test fun inlineDiffDeletionBasic() {
+        val html = render("[- deleted text -]")
+        assertContains(html, """class="idiff deletion"""", "deleted text")
+        assertContains(html, "<span", "</span>")
+    }
+
+    @Test fun inlineDiffAdditionInSentence() {
+        val html = render("The value is {+ new +} today.")
+        assertContains(html, "idiff addition", "new")
+        assertContains(html, "today")
+    }
+
+    @Test fun inlineDiffDeletionInSentence() {
+        val html = render("The value was [- old -] yesterday.")
+        assertContains(html, "idiff deletion", "old")
+        assertContains(html, "yesterday")
+    }
+
+    @Test fun inlineDiffBothInOneLine() {
+        val html = render("Change [- old -] to {+ new +}.")
+        assertContains(html, "idiff deletion", "idiff addition")
+    }
+
+    @Test fun inlineDiffMultipleAdditions() {
+        val html = render("{+ first +} and {+ second +}")
+        assertEquals(2, html.split("idiff addition").size - 1, "Expected 2 addition spans")
+    }
+
+    @Test fun inlineDiffMultipleDeletions() {
+        val html = render("[- first -] and [- second -]")
+        assertEquals(2, html.split("idiff deletion").size - 1, "Expected 2 deletion spans")
+    }
+
+    @Test fun inlineDiffAdditionPreservesInnerSpaces() {
+        val html = render("{+  spaced  +}")
+        assertContains(html, "idiff addition")
+        assertContains(html, "spaced")
+    }
+
+    @Test fun inlineDiffDeletionPreservesInnerSpaces() {
+        val html = render("[-  spaced  -]")
+        assertContains(html, "idiff deletion")
+        assertContains(html, "spaced")
+    }
+
+    @Test fun inlineDiffUnclosedAdditionIsLiteral() {
+        // No closing +} → should render as plain text
+        val html = render("{+ not closed")
+        assertNotContains(html, "idiff")
+    }
+
+    @Test fun inlineDiffUnclosedDeletionIsLiteral() {
+        val html = render("[- not closed")
+        assertNotContains(html, "idiff")
+    }
+
+    @Test fun inlineDiffInsideEmphasis() {
+        val html = render("**bold {+ added +} text**")
+        assertContains(html, "<strong>", "idiff addition")
+    }
+
+    @Test fun inlineDiffInsideCode_notParsed() {
+        // Inside backtick code span, markers should not be parsed as diffs
+        val html = render("`{+ not a diff +}`")
+        assertContains(html, "<code>")
+        assertNotContains(html, "idiff")
+    }
+
+    @Test fun inlineDiffAdditionNoSpaces() {
+        val html = render("{+nospace+}")
+        assertContains(html, "idiff addition", "nospace")
+    }
+
+    @Test fun inlineDiffDeletionNoSpaces() {
+        val html = render("[-nospace-]")
+        assertContains(html, "idiff deletion", "nospace")
+    }
+
+    @Test fun inlineDiffAdditionNoSpacesInSentence() {
+        val html = render("The {+quick+} brown fox")
+        assertContains(html, "idiff addition", "quick", "brown fox")
+    }
+
+    @Test fun inlineDiffDoesNotSpanLines() {
+        // GitLab inline diffs must open and close on the same line
+        val html = render("{+ first line\nsecond line +}")
+        assertNotContains(html, "idiff")
+    }
+
+    @Test fun inlineDiffDeletionDoesNotSpanLines() {
+        val html = render("[- first line\nsecond line -]")
+        assertNotContains(html, "idiff")
+    }
+
+    // ── 2. Emoji shortcodes ──────────────────────────────────────────────────
+
+    @Test fun emojiKnownRendersUnicode() {
+        val html = render(":heart:")
+        assertContains(html, "gl-emoji", "data-name=\"heart\"")
+        // Known emoji maps to Unicode
+        assertContains(html, "❤️")
+    }
+
+    @Test fun emojiKnownRendersSpan() {
+        val html = render(":rocket:")
+        assertContains(html, """<span class="gl-emoji"""", "data-name=\"rocket\"", "title=\":rocket:\"")
+    }
+
+    @Test fun emojiUnknownRendersShortcode() {
+        val html = render(":totally_unknown_emoji_xyz:")
+        assertContains(html, "gl-emoji", "totally_unknown_emoji_xyz")
+    }
+
+    @Test fun emojiMultipleOnOneLine() {
+        val html = render(":thumbsup: :tada: :sparkles:")
+        assertEquals(3, html.split("gl-emoji").size - 1, "Expected 3 emoji spans")
+    }
+
+    @Test fun emojiPlusOneShortcode() {
+        val html = render(":+1:")
+        assertContains(html, "gl-emoji", "+1")
+    }
+
+    @Test fun emojiAtStartOfLine() {
+        val html = render(":fire: This is hot")
+        assertContains(html, "gl-emoji", "This is hot")
+    }
+
+    @Test fun emojiAtEndOfLine() {
+        val html = render("Well done :clap:")
+        assertContains(html, "Well done", "gl-emoji")
+    }
+
+    @Test fun emojiInBoldText() {
+        val html = render("**:star: starred**")
+        assertContains(html, "<strong>", "gl-emoji")
+    }
+
+    @Test fun emojiNotParsedInCodeSpan() {
+        val html = render("`:smile:`")
+        assertContains(html, "<code>")
+        assertNotContains(html, "gl-emoji")
+    }
+
+    @Test fun emojiCustomMapOverrides() {
+        val flavour = GLFMFlavourDescriptor(
+            emojiMap = mapOf("custom" to "\uD83C\uDF89")
+        )
+        val markdown = ":custom:"
+        val tree = MarkdownParser(flavour).buildMarkdownTreeFromString(markdown)
+        val html = HtmlGenerator(markdown, tree, flavour).generateHtml()
+        assertContains(html, "gl-emoji", "custom", "\uD83C\uDF89")
+    }
+
+    @Test fun emojiEmptyShortcodeIsLiteral() {
+        // :: has no name between the colons → should not parse as emoji
+        val html = render("::")
+        assertNotContains(html, "gl-emoji")
+    }
+
+    @Test fun emojiNameWithSpacesIsLiteral() {
+        // Emoji names cannot contain spaces
+        val html = render(":foo bar:")
+        assertNotContains(html, "gl-emoji")
+    }
+
+    @Test fun colonsWithSpacedTextIsLiteral() {
+        // `a : b : c` — the colons are not emoji delimiters
+        val html = render("a : b : c")
+        assertNotContains(html, "gl-emoji")
+    }
+
+    @Test fun emojiTimeRangeNotParsed() {
+        // Times like 10:30:45 — "30" is between colons but this is not an emoji…
+        // GitLab does actually not render this as emoji; our parser accepts
+        // digit-only names though, matching :+1: style codes. Verify no crash
+        // and that the text is preserved either way.
+        val html = render("Meeting at 10:30:45 today")
+        assertContains(html, "10", "45", "today")
+    }
+
+    // ── 3. GitLab references ─────────────────────────────────────────────────
+
+    // User mentions
+    @Test fun refUserMentionBasic() {
+        val html = render("@alice")
+        assertContains(html, "gfm", "gfm-project_member", "@alice")
+        assertContains(html, "<a ", "href=")
+    }
+
+    @Test fun refUserMentionWithTrailingPunctuation() {
+        val html = render("Hey @bob, look at this")
+        assertContains(html, "gfm", "@bob")
+        // The comma must NOT be part of the link text
+        assertFalse(html.contains("@bob,"), "Comma should not be inside the link: $html")
+    }
+
+    @Test fun refUserMentionWithUnderscore() {
+        val html = render("@user_name")
+        assertContains(html, "gfm", "@user_name")
+    }
+
+    @Test fun refUserMentionWithDot() {
+        val html = render("@first.last")
+        assertContains(html, "gfm")
+    }
+
+    // Issue references
+    @Test fun refIssueBasic() {
+        val html = render("#42")
+        assertContains(html, "gfm", "gfm-issue", "#42")
+        assertContains(html, "href=")
+    }
+
+    @Test fun refIssueUrl() {
+        val html = render("#42", baseUrl = "https://gitlab.com", project = "ns/proj")
+        assertContains(html, "ns/proj/-/issues/42")
+    }
+
+    @Test fun refIssueMultiple() {
+        val html = render("#1 and #2")
+        assertEquals(2, html.split("gfm-issue").size - 1, "Expected 2 issue links")
+    }
+
+    // Merge-request references
+    @Test fun refMergeRequestBasic() {
+        val html = render("!99")
+        assertContains(html, "gfm", "gfm-merge_request", "!99")
+    }
+
+    @Test fun refMergeRequestUrl() {
+        val html = render("!7", baseUrl = "https://gitlab.com", project = "ns/proj")
+        assertContains(html, "ns/proj/-/merge_requests/7")
+    }
+
+    // Snippet references
+    @Test fun refSnippetBasic() {
+        val html = render("\$10")
+        assertContains(html, "gfm")
+    }
+
+    // Epic references
+    @Test fun refEpicBasic() {
+        val html = render("&5")
+        assertContains(html, "gfm")
+    }
+
+    // Label references
+    @Test fun refLabelUnquoted() {
+        val html = render("~bug")
+        assertContains(html, "gfm", "gfm-label", "bug")
+    }
+
+    @Test fun refLabelUrl() {
+        val html = render("~bug", baseUrl = "https://gitlab.com", project = "ns/proj")
+        assertContains(html, "label_name")
+    }
+
+    // Milestone references
+    @Test fun refMilestoneBasic() {
+        val html = render("%v1.0")
+        assertContains(html, "gfm")
+    }
+
+    @Test fun refLabelQuoted() {
+        val html = render("~\"multi word label\"")
+        assertContains(html, "gfm-label", "multi word label")
+    }
+
+    // Cross-project references
+    @Test fun refCrossProjectIssue() {
+        val html = render("other/project#123")
+        assertContains(html, "gfm", "#123")
+        assertContains(html, "href=")
+    }
+
+    @Test fun refCrossProjectUrl() {
+        val html = render("ns/proj#55", baseUrl = "https://gitlab.com")
+        assertContains(html, "ns/proj/-/issues/55")
+    }
+
+    @Test fun refNoReferenceInCodeSpan() {
+        val html = render("`#123`")
+        assertContains(html, "<code>")
+        assertNotContains(html, "gfm-issue")
+    }
+
+    @Test fun refIssueRequiresWordBoundary() {
+        // `#123abc` is not an issue reference (no word boundary after digits)
+        val html = render("#123abc")
+        assertNotContains(html, "gfm-issue")
+    }
+
+    @Test fun refMergeRequestRequiresWordBoundary() {
+        val html = render("!123abc")
+        assertNotContains(html, "gfm-merge_request")
+    }
+
+    @Test fun refArrayIndexingNotADeletion() {
+        // `arr[-1]` is array indexing, not an inline diff deletion
+        val html = render("arr[-1] indexing")
+        assertNotContains(html, "idiff")
+    }
+
+    @Test fun emailNotParsedAsMention() {
+        val html = render("test@example.com")
+        assertNotContains(html, "gfm-project_member")
+    }
+
+    @Test fun timeNotParsedAsEmoji() {
+        val html = render("10:30")
+        assertNotContains(html, "gl-emoji")
+    }
+
+    // ── 4. Alerts ────────────────────────────────────────────────────────────
+
+    @Test fun alertNote() {
+        val html = render("> [!note]\n> Content here")
+        assertContains(html, "gl-alert", "gl-alert-note", "Note")
+        assertContains(html, "Content here")
+    }
+
+    @Test fun alertTip() {
+        val html = render("> [!tip]\n> A helpful tip")
+        assertContains(html, "gl-alert-tip", "Tip")
+        assertContains(html, "A helpful tip")
+    }
+
+    @Test fun alertImportant() {
+        val html = render("> [!important]\n> Pay attention")
+        assertContains(html, "gl-alert-important", "Important")
+        assertContains(html, "Pay attention")
+    }
+
+    @Test fun alertCaution() {
+        val html = render("> [!caution]\n> Be careful")
+        assertContains(html, "gl-alert-caution", "Caution")
+        assertContains(html, "Be careful")
+    }
+
+    @Test fun alertWarning() {
+        val html = render("> [!warning]\n> Danger ahead")
+        assertContains(html, "gl-alert-warning", "Warning")
+        assertContains(html, "Danger ahead")
+    }
+
+    @Test fun alertCaseInsensitive() {
+        val html = render("> [!NOTE]\n> Upper case marker")
+        assertContains(html, "gl-alert-note")
+    }
+
+    @Test fun alertBodyNotContainsMarker() {
+        val html = render("> [!note]\n> Body text")
+        // The [!note] marker itself should not appear in the rendered body
+        assertFalse(html.contains("[!note]"), "Marker should be stripped from body: $html")
+        assertFalse(html.contains("[!NOTE]"), "Marker should be stripped from body: $html")
+    }
+
+    @Test fun alertMultiLineBody() {
+        val html = render("> [!note]\n> Line one\n> Line two")
+        assertContains(html, "gl-alert-note", "Line one", "Line two")
+    }
+
+    @Test fun alertContainsInlineDiff() {
+        val html = render("> [!warning]\n> Changed [- old -] to {+ new +}")
+        assertContains(html, "gl-alert-warning", "idiff deletion", "idiff addition")
+    }
+
+    @Test fun alertContainsEmoji() {
+        val html = render("> [!tip]\n> Great job :thumbsup:")
+        assertContains(html, "gl-alert-tip", "gl-emoji")
+    }
+
+    @Test fun unknownAlertMarkerIsPlainBlockquote() {
+        val html = render("> [!unknown]\n> Content")
+        assertNotContains(html, "gl-alert")
+        assertContains(html, "<blockquote>")
+    }
+
+    @Test fun plainBlockquoteUnaffected() {
+        val html = render("> Regular blockquote")
+        assertNotContains(html, "gl-alert")
+        assertContains(html, "<blockquote>")
+        assertContains(html, "Regular blockquote")
+    }
+
+    // ── 5. Multiline blockquotes ─────────────────────────────────────────────
+
+    @Test fun multilineBlockquoteSimple() {
+        val html = render(">>>\nLine one\n\nLine two\n>>>")
+        assertEquals(
+            "<body><blockquote><p>Line one</p><p>Line two</p></blockquote></body>",
+            html,
+        )
+    }
+
+    @Test fun multilineBlockquoteProducesOneParagraphPerBlock() {
+        val html = render(">>>\nParagraph one\n\nParagraph two\n>>>")
+        assertEquals(2, html.split("<p>").size - 1, "Expected 2 paragraphs")
+    }
+
+    @Test fun multilineBlockquoteWithInlineMarkup() {
+        val html = render(">>>\n**bold** and _italic_\n>>>")
+        assertContains(html, "<blockquote>", "<strong>", "<em>")
+    }
+
+    @Test fun multilineBlockquoteWithInlineDiff() {
+        val html = render(">>>\nChange [- old -] to {+ new +}\n>>>")
+        assertContains(html, "<blockquote>", "idiff deletion", "idiff addition")
+    }
+
+    @Test fun multilineBlockquoteWithEmoji() {
+        val html = render(">>>\nGreat :rocket:\n>>>")
+        assertContains(html, "<blockquote>", "gl-emoji")
+    }
+
+    @Test fun multilineBlockquoteEmpty() {
+        val html = render(">>>\n>>>")
+        assertContains(html, "<blockquote>", "</blockquote>")
+    }
+
+    // ── 6. Math (inherited from GFM) ─────────────────────────────────────────
+
+    @Test fun inlineMath() {
+        val html = render("Compute \$x^2\$.")
+        // GFM math renders as a span or similar — just check it's parsed
+        assertContains(html, "x^2")
+    }
+
+    @Test fun blockMath() {
+        val html = render("\$\$\nx = 1\n\$\$")
+        assertContains(html, "x = 1")
+    }
+
+    // ── 7. Strikethrough (inherited from GFM) ────────────────────────────────
+
+    @Test fun strikethrough() {
+        val html = render("~~strikethrough~~")
+        assertContains(html, "<span class=\"user-del\">" )
+        assertContains(html, "strikethrough")
+    }
+
+    @Test fun strikethroughWithDiffInside() {
+        val html = render("~~[- deleted -]~~")
+        assertContains(html, "user-del", "idiff deletion")
+    }
+
+    // ── 8. Tables (inherited from GFM) ───────────────────────────────────────
+
+    @Test fun basicTable() {
+        val html = render("| A | B |\n|---|---|\n| 1 | 2 |")
+        assertContains(html, "<table>", "<th>", "<td>", "</table>")
+    }
+
+    @Test fun tableWithDiffInCell() {
+        val html = render("| Before | After |\n|---|---|\n| [- old -] | {+ new +} |")
+        assertContains(html, "<table>", "idiff deletion", "idiff addition")
+    }
+
+    // ── 9. Task lists (inherited from GFM) ───────────────────────────────────
+
+    @Test fun taskListUnchecked() {
+        val html = render("- [ ] A pending item")
+        assertContains(html, "type=\"checkbox\"")
+        // Unchecked boxes must not have the `checked` attribute
+        assertFalse(
+            html.contains(" checked"),
+            "Unchecked task should not have 'checked' attribute: $html"
+        )
+    }
+
+    @Test fun taskListChecked() {
+        val html = render("- [x] A done item")
+        assertContains(html, "type=\"checkbox\"", "checked")
+    }
+
+    // ── 10. Edge cases & interactions ────────────────────────────────────────
+
+    @Test fun inlineDiffAndEmojiOnSameLine() {
+        val html = render("{+ great :rocket: +}")
+        assertContains(html, "idiff addition", "gl-emoji")
+    }
+
+    @Test fun referenceAndEmojiOnSameLine() {
+        val html = render("#1 :thumbsup:")
+        assertContains(html, "gfm-issue", "gl-emoji")
+    }
+    @Test
+    fun allFeaturesInOneDocument() {
+        val markdown = "# Heading\n\n" +
+            "Hey @alice, please review !42.\n\n" +
+            "Changes:\n" +
+            "- [- removed line -]\n" +
+            "- {+ added line +}\n\n" +
+            "Fixes #7. :white_check_mark:\n\n" +
+            "> [!note]\n" +
+            "> See also ~documentation.\n\n" +
+            ">>>\n" +
+            "This is a multiline blockquote.\n" +
+            ">>>\n\n" +
+            "| Feature | Status |\n" +
+            "|---------|--------|\n" +
+            "| Emoji   | :star: |\n"
+
+        val html = render(markdown)
+        assertContains(
+            html,
+            "<h1>",
+            "gfm-project_member",   // @alice
+            "gfm-merge_request",    // !42
+            "idiff deletion",       // [- removed -]
+            "idiff addition",       // {+ added +}
+            "gfm-issue",            // #7
+            "gl-emoji",             // :white_check_mark:
+            "gl-alert-note",        // [!note] alert
+            "<blockquote>",         // >>> multiline blockquote
+        )
+    }
+
+    @Test fun noSpuriousHtmlInPlainMarkdown() {
+        // Plain GFM features still work without GLFM interference
+        val html = render("Hello **world** and `code`.")
+        assertContains(html, "<strong>world</strong>", "<code>code</code>")
+        assertNotContains(html, "gl-emoji", "gl-alert", "idiff", "gfm-issue")
+    }
+
+    @Test fun basicMarkdownStillWorks() {
+        val html = render("# H1\n\nPlain **text**.")
+        assertEquals("<body><h1>H1</h1><p>Plain <strong>text</strong>.</p></body>", html)
+    }
+
+    @Test fun emptyDocument() {
+        val html = render("")
+        // Should not throw; body may be empty or minimal
+        assertNotContains(html, "Exception", "Error")
+    }
+
+    @Test fun onlyWhitespace() {
+        val html = render("   \n   ")
+        assertNotContains(html, "Exception", "Error")
+    }
+
+    @Test fun inlineDiffNotConfusedByLinkSyntax() {
+        // A real link [text](url) should not be confused with deletion syntax
+        val html = render("[link text](https://example.com)")
+        assertNotContains(html, "idiff")
+        assertContains(html, "<a ", "href=")
+    }
+
+    @Test fun emojiInHeading() {
+        val html = render("# Hello :wave:")
+        assertContains(html, "<h1>", "gl-emoji")
+    }
+
+    @Test fun inlineDiffInHeading() {
+        val html = render("# Changed [- old -] to {+ new +}")
+        assertContains(html, "<h1>", "idiff deletion", "idiff addition")
+    }
+
+    @Test fun alertTitleIsCapitalizedKind() {
+        listOf("note", "tip", "important", "caution", "warning").forEach { kind ->
+            val html = render("> [!$kind]\n> body")
+            val expectedTitle = kind.replaceFirstChar { it.uppercaseChar() }
+            assertContains(html, expectedTitle)
+        }
+    }
+
+    @Test fun multilineBlockquoteDoesNotLeakFenceText() {
+        val html = render(">>>\nContent\n>>>")
+        // The raw >>> chars should not appear as visible text
+        assertFalse(
+            Regex(">>>").containsMatchIn(html.replace("<", " <").replace(">", "> ")),
+            "Fence markers should not appear as text: $html"
+        )
+    }
+
+    @Test fun userMentionLinkPointsToCorrectUrl() {
+        val html = render("@charlie", baseUrl = "https://gitlab.com")
+        assertContains(html, "https://gitlab.com/charlie")
+    }
+
+    @Test fun issueReferenceLinkPointsToCorrectUrl() {
+        val html = render("#5", baseUrl = "https://gitlab.com", project = "grp/proj")
+        assertContains(html, "grp/proj/-/issues/5")
+    }
+
+    @Test fun mergeRequestLinkPointsToCorrectUrl() {
+        val html = render("!3", baseUrl = "https://gitlab.com", project = "grp/proj")
+        assertContains(html, "grp/proj/-/merge_requests/3")
+    }
+}


### PR DESCRIPTION
## Summary

This PR introduces a new `GLFMFlavourDescriptor` implementing [GitLab Flavored Markdown](https://docs.gitlab.com/ee/user/markdown.html) on top of the existing `GFMFlavourDescriptor`.

## Features

| Feature | Syntax | Rendered as |
|---------|--------|-------------|
| Inline diff addition | `{+ added +}` / `{+added+}` | `<span class="idiff addition">` |
| Inline diff deletion | `[- removed -]` / `[-removed-]` | `<span class="idiff deletion">` |
| Emoji shortcodes | `:smile:`, `:+1:` | `<span class="gl-emoji">` with Unicode emoji (customizable map) |
| User mention | `@user` | link with `gfm-project_member` |
| Issue reference | `#123`, `group/project#123` | link with `gfm-issue` |
| Merge request | `!123` | link with `gfm-merge_request` |
| Snippet / Epic | `$123` / `&123` | `gfm-snippet` / `gfm-epic` links |
| Label | `~bug`, `~"multi word"` | link with `gfm-label` |
| Milestone | `%v1.0` | link with `gfm-milestone` |
| Alerts | `> [!note]` (also tip/important/caution/warning) | `<div class="gl-alert gl-alert-note">` |
| Multiline blockquote | `>>>` … `>>>` | single `<blockquote>` |

## Design notes

- **Zero changes to existing files** — everything lives in a new `flavours/glfm` package (commonMain) plus one test file.
- Reuses the GFM lexer as-is; GitLab-specific inline syntax is handled by new `SequentialParser` implementations (`InlineDiffParser`, `EmojiParser`, `GitLabReferenceParser`) that work with the token shapes the GFM lexer produces.
- Multiline blockquotes use a `MarkerBlockProvider` + `MarkerBlock` pair; the fence artifacts are flattened at HTML generation time.
- Alerts are detected at HTML generation time on top of regular blockquotes (the `[!note]` marker parses as a `SHORT_REFERENCE_LINK`, which the alert provider recognizes and strips).
- Parser correctness details: inline diffs cannot span lines, numeric references require a word boundary (`#123abc` is not a reference), `arr[-1]` is not a deletion, `~~strikethrough~~` is not a label, emails are not mentions, and emoji names cannot contain whitespace.

## Configuration

```kotlin
val flavour = GLFMFlavourDescriptor(
    gitlabBaseUrl = "https://gitlab.com",
    gitlabProject = "group/project",
    emojiMap = customEmojiMap, // optional
)
```

## Testing

- 100+ new unit tests in `GLFMFeaturesTest` covering every feature, inherited GFM behaviour (math, strikethrough, tables, task lists) and edge-case interactions.
- Full `jvmTest` suite passes (1617 tests, 0 failures); JS target compiles.

## Notes for reviewers

- Cross-project references mid-sentence (`see group/project#1`) are not detected because the GFM lexer emits the whole phrase as one TEXT token which sequential parsers cannot split; standalone occurrences work.
- Draft status: opening early for direction feedback — happy to adjust API shape (e.g. reference URL building could be pluggable instead of `gitlabBaseUrl`/`gitlabProject` string params).