### PR TITLE
Don't include `[]` in a link label if on new line

### DIFF
--- a/src/commonMain/kotlin/org/intellij/markdown/parser/sequentialparsers/impl/ReferenceLinkParser.kt
+++ b/src/commonMain/kotlin/org/intellij/markdown/parser/sequentialparsers/impl/ReferenceLinkParser.kt
@@ -65,23 +65,20 @@ class ReferenceLinkParser : SequentialParser {
 
             val linkLabel = LinkParserUtil.parseLinkLabel(iterator)
                     ?: return null
-            
+
             var it = linkLabel.iteratorPosition
             val shortcutLinkEnd = it
 
             it = it.advance()
-            if (it.type == MarkdownTokenTypes.EOL) {
-                it = it.advance()
-            }
 
-            if (it.type == MarkdownTokenTypes.LBRACKET && it.rawLookup(1) == MarkdownTokenTypes.RBRACKET) {
+            if (it.start == shortcutLinkEnd.end && it.type == MarkdownTokenTypes.LBRACKET && it.rawLookup(1) == MarkdownTokenTypes.RBRACKET) {
                 it = it.advance()
             } else {
                 it = shortcutLinkEnd
             }
 
             return LocalParsingResult(it,
-                    linkLabel.parsedNodes 
+                    linkLabel.parsedNodes
                             + SequentialParser.Node(startIndex..it.index + 1, MarkdownElementTypes.SHORT_REFERENCE_LINK),
                     linkLabel.rangesToProcessFurther)
         }

--- a/src/fileBasedTest/resources/data/parser/referenceLinks.md
+++ b/src/fileBasedTest/resources/data/parser/referenceLinks.md
@@ -20,6 +20,15 @@
 [foo]
 []
 
+[foo]
+text
+
 [*foo* bar]
 
 [[*foo* bar]]
+
+[foo]`bar`[baz]
+
+[foo]`bar`[baz]`qux`[quux]
+
+[foo] [bar][baz]

--- a/src/fileBasedTest/resources/data/parser/referenceLinks.txt
+++ b/src/fileBasedTest/resources/data/parser/referenceLinks.txt
@@ -132,9 +132,19 @@ Markdown:MARKDOWN_FILE
         Markdown:[('[')
         Markdown:TEXT('foo')
         Markdown:](']')
-      Markdown:EOL('\n')
-      Markdown:[('[')
-      Markdown:](']')
+    Markdown:EOL('\n')
+    Markdown:[('[')
+    Markdown:](']')
+  Markdown:EOL('\n')
+  Markdown:EOL('\n')
+  Markdown:PARAGRAPH
+    Markdown:SHORT_REFERENCE_LINK
+      Markdown:LINK_LABEL
+        Markdown:[('[')
+        Markdown:TEXT('foo')
+        Markdown:](']')
+    Markdown:EOL('\n')
+    Markdown:TEXT('text')
   Markdown:EOL('\n')
   Markdown:EOL('\n')
   Markdown:PARAGRAPH
@@ -163,3 +173,64 @@ Markdown:MARKDOWN_FILE
         Markdown:TEXT('bar')
         Markdown:](']')
     Markdown:](']')
+  Markdown:EOL('\n')
+  Markdown:EOL('\n')
+  Markdown:PARAGRAPH
+    Markdown:SHORT_REFERENCE_LINK
+      Markdown:LINK_LABEL
+        Markdown:[('[')
+        Markdown:TEXT('foo')
+        Markdown:](']')
+    Markdown:CODE_SPAN
+      Markdown:BACKTICK('`')
+      Markdown:TEXT('bar')
+      Markdown:BACKTICK('`')
+    Markdown:SHORT_REFERENCE_LINK
+      Markdown:LINK_LABEL
+        Markdown:[('[')
+        Markdown:TEXT('baz')
+        Markdown:](']')
+  Markdown:EOL('\n')
+  Markdown:EOL('\n')
+  Markdown:PARAGRAPH
+    Markdown:SHORT_REFERENCE_LINK
+      Markdown:LINK_LABEL
+        Markdown:[('[')
+        Markdown:TEXT('foo')
+        Markdown:](']')
+    Markdown:CODE_SPAN
+      Markdown:BACKTICK('`')
+      Markdown:TEXT('bar')
+      Markdown:BACKTICK('`')
+    Markdown:SHORT_REFERENCE_LINK
+      Markdown:LINK_LABEL
+        Markdown:[('[')
+        Markdown:TEXT('baz')
+        Markdown:](']')
+    Markdown:CODE_SPAN
+      Markdown:BACKTICK('`')
+      Markdown:TEXT('qux')
+      Markdown:BACKTICK('`')
+    Markdown:SHORT_REFERENCE_LINK
+      Markdown:LINK_LABEL
+        Markdown:[('[')
+        Markdown:TEXT('quux')
+        Markdown:](']')
+  Markdown:EOL('\n')
+  Markdown:EOL('\n')
+  Markdown:PARAGRAPH
+    Markdown:SHORT_REFERENCE_LINK
+      Markdown:LINK_LABEL
+        Markdown:[('[')
+        Markdown:TEXT('foo')
+        Markdown:](']')
+    WHITE_SPACE(' ')
+    Markdown:FULL_REFERENCE_LINK
+      Markdown:LINK_TEXT
+        Markdown:[('[')
+        Markdown:TEXT('bar')
+        Markdown:](']')
+      Markdown:LINK_LABEL
+        Markdown:[('[')
+        Markdown:TEXT('baz')
+        Markdown:](']')


### PR DESCRIPTION
Replaces #177, though; looks like most of the issues were already fixed in 30f606b85b15f235c43440a11ccb240295aa4586. :)

The only changes that were left here are some small fixes for handling of short links in edge cases - see test changes on lines 135-137 - they are different only by indentation. Everything else is the same before and after those changes.

Now, the behavior of `[]` on a new line is the same, as if there was just any other text on a new line - this seems correct? I don't know TBH. But it looks similar to what https://spec.commonmark.org/0.31.2/#example-556 says.