### PR TITLE
fix: never split a node at the streaming parser's stable boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 # IntelliJ Markdown Changelog
 
 ## [Unreleased]
+- Keep a block that spans the streaming parser's stable boundary whole instead of dropping it
 
 ## 0.7.12
 - End a link label at a blank line, also when the line ends with a carriage return

--- a/src/commonMain/kotlin/org/intellij/markdown/parser/MarkdownParser.kt
+++ b/src/commonMain/kotlin/org/intellij/markdown/parser/MarkdownParser.kt
@@ -97,7 +97,7 @@ class MarkdownParser(
             val (tree, openMarkers) = doParse(root, text, parseInlines, baseOffset)
             StreamingMarkdownParseResult(
                 tree = tree,
-                unstableStartOffset = findUnstableStartOffset(openMarkers, text, baseOffset)
+                unstableStartOffset = keepNodesWhole(tree, findUnstableStartOffset(openMarkers, text, baseOffset))
             )
         }
         catch (e: MarkdownParsingException) {
@@ -160,6 +160,14 @@ class MarkdownParser(
         unstableStartOffset = minOf(lastBlankLineEnd, unstableStartOffset)
         return unstableStartOffset + baseOffset
     }
+
+    /**
+     * [StreamingMarkdownFile] splits the children of [tree] at [offset], so a child spanning it would end up on
+     * neither side. A closed block that contains a blank line, such as a fenced code block, can span the offset
+     * found by [findUnstableStartOffset]; move the offset back to where that block starts.
+     */
+    private fun keepNodesWhole(tree: ASTNode, offset: Int): Int =
+        tree.children.firstOrNull { it.startOffset < offset && offset < it.endOffset }?.startOffset ?: offset
 
     /**
      * Return the exclusive end of the last blank line in the string.

--- a/src/commonTest/kotlin/org/intellij/markdown/parser/StreamingMarkdownFileTest.kt
+++ b/src/commonTest/kotlin/org/intellij/markdown/parser/StreamingMarkdownFileTest.kt
@@ -174,6 +174,36 @@ class StreamingMarkdownFileTest {
         }
     }
 
+    @Test
+    fun codeFenceSpanningTheLastBlankLineIsNotSplit() {
+        // Appending one character at a time makes the blank line inside the fence the last blank line at some point.
+        val text: CharSequence = "```\ncode\n\nmore code\n```\n\nfollowing text\n"
+        val file = EmptyStreamingMarkdownFile()
+        text.forEach { file.append(it.toString()) }
+
+        val expected = MarkdownParser(GFMFlavourDescriptor(), cancellationToken = CancellationToken.NonCancellable)
+            .buildMarkdownTreeFromString(text)
+            .children
+
+        assertEquals(
+            expected.map { Triple(it.type, it.startOffset, it.endOffset) },
+            file.children.map { Triple(it.type, it.startOffset, it.endOffset) }
+        )
+    }
+
+    @Test
+    fun childrenAlwaysCoverTheWholeText() {
+        val file = EmptyStreamingMarkdownFile()
+
+        "# heading\n\nparagraph\n\n```\ncode\n\nmore\n```\n\n> quote\n\ntext\n".forEach {
+            file.append(it.toString())
+            assertEquals(
+                listOf(0) + file.children.map { it.endOffset },
+                file.children.map { it.startOffset } + file.endOffset
+            )
+        }
+    }
+
     private class TestCancellationException : RuntimeException()
 
     private fun assertTopLevelTypes(nodes: List<ASTNode>, vararg types: IElementType) {


### PR DESCRIPTION
## Problem

`StreamingMarkdownFileImpl.append` divides the parsed children into a stable prefix (`endOffset <= boundary`) and an unstable tail (`startOffset >= boundary`), and deletes the stabilized text from its buffer. A closed block spanning the boundary matches neither filter, so it is dropped, and the text after the boundary is reparsed as if the block had never opened.

A fenced code block containing a blank line triggers it: the fence is closed, so it is not among the open markers `findUnstableStartOffset` clamps to, yet it holds the last blank line. Appending `` "```\ncode\n\nmore code\n```\n\nfollowing text\n" `` one character at a time yields a paragraph `more code` and drops `following text` entirely, where a full parse gives a code fence and a paragraph. Found while streaming LLM output in Firefox for Android, the same context as #210.

## Approach

Clamp the boundary in `parseStreaming`, where the freshly built tree is in scope with the same absolute offsets: if a top-level node spans the boundary, move it back to that node's start. Moving the boundary earlier only stabilizes less, so it cannot make a previously correct split wrong.

#222 clamps the same offset for a different reason (a list at the end of the text). The two compose in either order; whichever lands second chains the calls.

## Tests

The fence repro compared child by child against a full parse, and an invariant that the children tile `[0, endOffset)` after every append of a mixed document. Both fail without the fix.
